### PR TITLE
Tweaks for internal CI

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ FROM mcr.microsoft.com/playwright:v1.20.0-focal
 RUN curl -sL https://github.com/stedolan/jq/releases/download/jq-1.6/jq-linux64 -o /usr/local/bin/jq && chmod a+x /usr/local/bin/jq
 
 ENV CI=true
-RUN useradd --no-log-init -rm -d /opt/playwright -s /bin/bash -g root -u 1001 playwright
+RUN useradd --no-log-init -rm -d /opt/playwright -s /bin/bash -g root -o -u 1000 playwright
 
 COPY . /opt/playwright
 
@@ -17,7 +17,7 @@ RUN chown -R playwright:root /opt/playwright && \
     chgrp -R 0 /ms-playwright && \
     chmod -R 775 /ms-playwright
 
-USER 1001
+USER 1000
 WORKDIR /opt/playwright
 ENV HOME=/opt/playwright
 

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -40,7 +40,9 @@ const config: PlaywrightTestConfig = {
 
     /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
     trace: 'retain-on-failure',
-    screenshot: 'on'
+    screenshot: 'on',
+    /* ignore https certificate authority if STARTING_PAGE is defined */
+    ignoreHTTPSErrors: process.env.STARTING_PAGE ? true : false,
   },
 
   /* Configure projects for major browsers */


### PR DESCRIPTION
Use user `1000` instead of `1001` to conform with pre-existing standards.
Ignore Https checks if an alternative `STARTING_PAGE` is provided.