### PR TITLE
Reliable selectors for Topics

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ node_modules/
 /playwright/.cache/
 .env
 .*_env
+.DS_Store

--- a/lib/kafka.ts
+++ b/lib/kafka.ts
@@ -29,8 +29,6 @@ export const deleteKafkaInstance = async function (page: Page, name: string, awa
 
   await row.locator('[aria-label="Actions"]').click();
   await page.locator('button', { hasText: 'Delete instance' }).click();
-  // await page.getByText('Delete instance').click();
-
   try {
     await expect(page.locator('input[name="mas-name-input"]')).toHaveCount(1, {
       timeout: 1000
@@ -42,8 +40,6 @@ export const deleteKafkaInstance = async function (page: Page, name: string, awa
   }
   // data-testid=modalDeleteKafka-buttonDelete
   await page.locator('button', { hasText: 'Delete' }).click();
-  // await page.getByTestId('modalDeleteKafka-buttonDelete').click();
-
   // await for the instance to be deleted
   if (awaitDeletion) {
     await expect(page.getByText(`${name}`, { exact: true })).toHaveCount(0, {

--- a/lib/kafka.ts
+++ b/lib/kafka.ts
@@ -3,22 +3,18 @@ import { config } from './config';
 
 export const navigateToKafkaList = async function (page: Page) {
   await page.getByRole('link', { name: 'Application and Data Services' }).click();
-  // }
   await page.getByRole('button', { name: 'Streams for Apache Kafka' }).click();
   await page.getByRole('link', { name: 'Kafka Instances' }).click();
   await expect(page.getByRole('heading', { name: 'Kafka Instances' })).toHaveCount(1);
 };
 
 export const createKafkaInstance = async function (page: Page, name: string, check = true) {
-  await page.getByText('Create Kafka instance').click();
-
+  await page.locator('button', { hasText: 'Create Kafka instance' }).click();
   await expect(page.getByText('Create a Kafka instance')).toHaveCount(1);
-
   await page.waitForSelector('[role=progressbar]', { state: 'detached' });
-
   await page.getByLabel('Name *').fill(name);
-
-  await page.getByTestId('modalCreateKafka-buttonSubmit').click();
+  // data-testid=modalCreateKafka-buttonSubmit
+  await page.locator('button', { hasText: 'Create instance'}).click()
 
   if (check) {
     // check for the instance to have been created
@@ -32,8 +28,8 @@ export const deleteKafkaInstance = async function (page: Page, name: string, awa
   const row = page.locator('tr', { has: instanceLinkSelector });
 
   await row.locator('[aria-label="Actions"]').click();
-
-  await page.getByText('Delete instance').click();
+  await page.locator('button', { hasText: 'Delete instance' }).click();
+  // await page.getByText('Delete instance').click();
 
   try {
     await expect(page.locator('input[name="mas-name-input"]')).toHaveCount(1, {
@@ -44,7 +40,9 @@ export const deleteKafkaInstance = async function (page: Page, name: string, awa
     // Removal without confirmation
     // ignore
   }
-  await page.getByTestId('modalDeleteKafka-buttonDelete').click();
+  // data-testid=modalDeleteKafka-buttonDelete
+  await page.locator('button', { hasText: 'Delete' }).click();
+  // await page.getByTestId('modalDeleteKafka-buttonDelete').click();
 
   // await for the instance to be deleted
   if (awaitDeletion) {

--- a/lib/topic.ts
+++ b/lib/topic.ts
@@ -1,7 +1,5 @@
 import { expect, Page } from '@playwright/test';
 import { waitForKafkaReady } from './kafka';
-import { config } from './config';
-import { text } from 'stream/consumers';
 
 export const navigateToKafkaTopicsList = async function (page: Page, kafkaName: string) {
   await expect(page.getByText(kafkaName)).toHaveCount(1);

--- a/lib/topic.ts
+++ b/lib/topic.ts
@@ -1,22 +1,25 @@
 import { expect, Page } from '@playwright/test';
 import { waitForKafkaReady } from './kafka';
+import { config } from './config';
+import { text } from 'stream/consumers';
 
 export const navigateToKafkaTopicsList = async function (page: Page, kafkaName: string) {
   await expect(page.getByText(kafkaName)).toHaveCount(1);
   await waitForKafkaReady(page, kafkaName);
-  await page.getByText(kafkaName).click();
-  await page.getByText('Topics', { exact: true }).click();
+  await page.locator('a', { hasText: kafkaName }).click();
+  // data-testid=pageKafka-tabTopics
+  await page.locator('button', { hasText: 'Topics' }).click();
 };
 
 export const createKafkaTopic = async function (page: Page, name: string) {
-  await page.getByText('Create topic', { exact: true }).click();
+  await page.locator('button', { hasText: 'Create topic'}).click()
   await expect(page.getByText('Create topic')).toHaveCount(2);
   // This is default Topic creation
   await page.getByPlaceholder('Enter topic name').fill(name);
   for (let i = 0; i < 3; i++) {
-    await page.getByText('Next').click();
+    await page.locator('button', { hasText: 'Next'}).click()
   }
-  await page.getByText('Finish').click();
+  await page.locator('button', { hasText: 'Finish'}).click()
   await expect(page.getByText(name)).toHaveCount(1);
 };
 
@@ -25,9 +28,11 @@ export const deleteKafkaTopic = async function (page: Page, name: string) {
   const row = page.locator('tr', { has: instanceLinkSelector });
 
   await row.locator('[aria-label="Actions"]').click();
-  await page.getByText('Delete', { exact: true }).click();
+  // data-testid=tableTopics-actionDelete
+  await page.locator('button >> text=Delete').click();
   await page.getByLabel('Type DELETE to confirm:').click();
   await page.getByLabel('Type DELETE to confirm:').fill('DELETE');
-  await page.getByTestId('modalDeleteTopic-buttonDelete').click();
+  // data-testid=modalDeleteTopic-buttonDelete
+  await page.locator('button', { hasText: 'Delete'}).click()
   await expect(page.getByText(name)).toHaveCount(0);
 };

--- a/lib/topic.ts
+++ b/lib/topic.ts
@@ -27,7 +27,7 @@ export const deleteKafkaTopic = async function (page: Page, name: string) {
 
   await row.locator('[aria-label="Actions"]').click();
   // data-testid=tableTopics-actionDelete
-  await page.locator('button >> text=Delete').click();
+  await page.locator('button', { hasText: 'Delete'}).click()
   await page.getByLabel('Type DELETE to confirm:').click();
   await page.getByLabel('Type DELETE to confirm:').fill('DELETE');
   // data-testid=modalDeleteTopic-buttonDelete

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -34,8 +34,8 @@ const config: PlaywrightTestConfig = {
   reporter: process.env.CI ? [['line'], ['github'], ['junit', { outputFile: 'results.xml' }]] : 'html',
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
   use: {
-    /* Maximum time each action such as `click()` can take. Defaults to 0 (no limit). */
-    actionTimeout: 0,
+    /* Maximum time each action such as `click()` can take. Defaults to 10000 (0 means no limit). */
+    actionTimeout: 60000,
     /* Base URL to use in actions like `await page.goto('/')`. */
     // baseURL: 'http://localhost:3000',
 

--- a/tests/kas.spec.ts
+++ b/tests/kas.spec.ts
@@ -91,8 +91,10 @@ test('test Kafka list filtered by status', async ({ page }) => {
 
   await deleteKafkaInstance(page, testInstanceName, false);
 
-  await filterByStatus(page, 'Deleting');
-  await expect(page.getByText(testInstanceName)).toBeTruthy();
+  // TODO: Probably race condition when deleting is finished too quickly
+  // Currently it just make the test flaky so we should discuss what we will do with it
+  // await filterByStatus(page, 'Deleting');
+  // await expect(page.getByText(testInstanceName)).toBeTruthy();
 
   // await for the kafka instance to be deleted
   await expect(page.getByText(`${testInstanceName}`, { exact: true })).toHaveCount(0, {

--- a/tests/kas.spec.ts
+++ b/tests/kas.spec.ts
@@ -93,8 +93,8 @@ test('test Kafka list filtered by status', async ({ page }) => {
 
   // TODO: Probably race condition when deleting is finished too quickly
   // Currently it just make the test flaky so we should discuss what we will do with it
-  // await filterByStatus(page, 'Deleting');
-  // await expect(page.getByText(testInstanceName)).toBeTruthy();
+  await filterByStatus(page, 'Deleting');
+  await expect(page.getByText(testInstanceName)).toBeTruthy();
 
   // await for the kafka instance to be deleted
   await expect(page.getByText(`${testInstanceName}`, { exact: true })).toHaveCount(0, {


### PR DESCRIPTION
This PR use more reliable selectors mostly for work with Topics. The changes should remove flakiness which was caused by clicking on the wrong page parts. For example, when the tests were trying to pick `Topics` button from the top menu, it actually used pop-up window after Kafka creation where it identified text `topics` as the match.

It also changes the default timeout for most of the operations to 60s to avoid issues that 1 test will take 20 minutes when there is no element with specific text, which should immediately fail.

We agreed with David to not use `data-testid` as it is only available for a few elements.

Test for Kafka filtering is quite flaky when Kafka instance is deleted to quickly (from my experience it was 50% of the test execution) so I commented out one check and we have to think about how we will deal with it.