### PR TITLE
Add kafkajs with producer and consumer

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -3,5 +3,8 @@ module.exports = {
   extends: ['eslint:recommended', 'plugin:@typescript-eslint/recommended', 'plugin:playwright/playwright-test'],
   parser: '@typescript-eslint/parser',
   plugins: ['@typescript-eslint'],
+  rules: {
+    "playwright/no-skipped-test": "off",
+  },
   root: true,
 };

--- a/lib/clients.ts
+++ b/lib/clients.ts
@@ -1,0 +1,133 @@
+import { Consumer, Producer, Kafka, EachMessagePayload, logLevel } from 'kafkajs';
+
+class KafkaClient {
+    clientId: string;
+    bootstrapServer: string;
+    kafka: Kafka;
+
+    constructor(clientId: string, bootstrapServer: string) {
+        this.clientId = clientId
+        this.bootstrapServer = bootstrapServer
+        this.kafka = new Kafka({
+            brokers: [bootstrapServer],
+            clientId: clientId,
+            ssl: true,
+            sasl: {
+                mechanism: 'plain',
+                username: '48b75664-b3d6-4e13-a5ef-0d10d0e1a536',
+                password: '0tG5Nb0ku8IzEduh1yKZ3SuyZ2iQrsfW',
+            },
+            logLevel: logLevel.INFO
+          })
+    }
+}
+
+export class KafkaProducer extends KafkaClient {
+    
+    private producer: Producer
+
+    constructor(clientId: string, bootstrapServer: string) {
+        super(clientId, bootstrapServer)
+        this.producer = this.kafka.producer()
+    }
+
+    async produceMessages(topicName: string, messageCount: number, key: string) {
+        await this.producer.connect()
+        
+        const messages = this.generateMessages(messageCount, key)
+        return await this.producer
+            .send({
+                topic: topicName,
+                messages: messages,
+                acks: -1,
+            })
+            .then(response => {
+                this.kafka.logger().info(`Messages sent #${response}`, {
+                response,
+                messageCount,
+                })
+                return true  
+            })
+            .catch(e => {
+                this.kafka.logger().error(`[${KafkaProducer.name}] ${e.message}`, { stack: e.stack })
+                return false
+            })
+    }
+
+    private generateMessage(key: String) {
+        return {
+            key: `key-${key}`,
+            value: `value-${key}-${new Date().toISOString()}`,
+        }
+    }
+
+    private generateMessages(messageCount: number, key: string) {
+        return Array(messageCount)
+            .fill(this.generateMessage(key))
+    }
+}
+
+export class KafkaConsumer extends KafkaClient {
+
+    private kafkaConsumer: Consumer
+
+    constructor(clientId: string, bootstrapServer: string, consumerGroup: string) {
+        super(clientId, bootstrapServer)
+        this.kafkaConsumer = this.kafka.consumer({ groupId: consumerGroup })
+    }
+
+
+    public async consumeMessages(topic: string, consumerGroup: string, messageCount: number, fromBeginning: boolean = true) {   
+    let msgCount = 1;
+    let test
+
+        try {
+            await this.kafkaConsumer.connect()
+            await this.kafkaConsumer.subscribe({ topic: topic, fromBeginning: fromBeginning })
+        
+            await this.kafkaConsumer.run({
+                eachMessage: async (messagePayload: EachMessagePayload) => {
+                    const { topic, partition, message } = messagePayload
+                    const prefix = `${topic}[${partition} | ${message.offset}] / ${message.timestamp}`
+                    console.log(`- ${prefix} ${message.key}#${message.value} -> ${msgCount}`)
+                    msgCount++
+                    if (msgCount >= messageCount) {
+                        test = Promise.resolve(msgCount) 
+                    }
+                }
+            })
+        } catch (error) {
+            console.log('Error: ', error)
+            return false
+        }
+
+        const timeout = new Promise<never>((_, reject) => {
+            setTimeout(() => {
+              reject(false);
+            }, 40000);
+          });
+
+        const succeeded = new Promise((resolve, _) => {
+            if (msgCount >= messageCount) {
+                console.log(msgCount)
+                resolve(true)
+            }
+        })
+
+        return Promise.race([test, timeout])
+
+        // return await new Promise((resolve, _) => {
+        //     setTimeout(() => {
+        //         if (msgCount <= messageCount) {
+        //             console.log(msgCount)
+        //             resolve(true)
+        //         } 
+        //     }, 20000)
+        // }) 
+    }
+    
+    public async shutdown(): Promise<void> {
+        await this.kafkaConsumer.disconnect()
+    }
+}
+

--- a/lib/clients.ts
+++ b/lib/clients.ts
@@ -75,7 +75,7 @@ export class KafkaConsumer extends KafkaClient {
     this.kafkaConsumer = this.kafka.consumer({ groupId: consumerGroup });
   }
 
-  public async consumeMessages(topic: string, expectedMsgCount: number, fromBeginning = true): Promise<boolean> {
+  public async consumeMessages(topic: string, expectedMsgCount: number, fromBeginning = true): Promise<number> {
     let msgCount = 0;
 
     try {
@@ -99,9 +99,9 @@ export class KafkaConsumer extends KafkaClient {
       setTimeout(() => {
         if (msgCount >= expectedMsgCount) {
           console.log('Received: ' + msgCount);
-          resolve(true);
+          resolve(msgCount);
         } else {
-          reject(false);
+          reject(0);
         }
       }, 20000);
     });

--- a/lib/clients.ts
+++ b/lib/clients.ts
@@ -97,7 +97,7 @@ export class KafkaConsumer extends KafkaClient {
 
     return await new Promise((resolve, reject) => {
       setTimeout(() => {
-        if (msgCount <= expectedMsgCount) {
+        if (msgCount >= expectedMsgCount) {
           console.log('Received: ' + msgCount);
           resolve(true);
         } else {

--- a/lib/clients.ts
+++ b/lib/clients.ts
@@ -75,11 +75,7 @@ export class KafkaConsumer extends KafkaClient {
     this.kafkaConsumer = this.kafka.consumer({ groupId: consumerGroup });
   }
 
-  public async consumeMessages(
-    topic: string,
-    expectedMsgCount: number,
-    fromBeginning = true
-  ): Promise<boolean> {
+  public async consumeMessages(topic: string, expectedMsgCount: number, fromBeginning = true): Promise<boolean> {
     let msgCount = 0;
 
     try {

--- a/lib/clients.ts
+++ b/lib/clients.ts
@@ -110,6 +110,9 @@ export class KafkaConsumer extends KafkaClient {
       } catch (error) {
         console.log('Error: ', error);
         reject(error);
+      } finally {
+        // shutdown consumer
+        this.shutdown();
       }
     });
   }

--- a/lib/clients.ts
+++ b/lib/clients.ts
@@ -55,7 +55,7 @@ export class KafkaProducer extends KafkaClient {
       });
   }
 
-  private generateMessage(key: String) {
+  private generateMessage(key: string) {
     return {
       key: `key-${key}`,
       value: `value-${key}-${new Date().toISOString()}`
@@ -78,7 +78,7 @@ export class KafkaConsumer extends KafkaClient {
   public async consumeMessages(
     topic: string,
     expectedMsgCount: number,
-    fromBeginning: boolean = true
+    fromBeginning = true
   ): Promise<boolean> {
     let msgCount = 0;
 

--- a/lib/clients.ts
+++ b/lib/clients.ts
@@ -1,117 +1,117 @@
 import { Consumer, Producer, Kafka, EachMessagePayload, logLevel } from 'kafkajs';
 
 class KafkaClient {
-    bootstrapServer: string;
-    username: string;
-    password: string;
-    kafka: Kafka;
+  bootstrapServer: string;
+  username: string;
+  password: string;
+  kafka: Kafka;
 
-    constructor(bootstrapServer: string, username: string, password: string) {
-        this.bootstrapServer = bootstrapServer
-        this.username = username
-        this.password = password
-        this.kafka = new Kafka({
-            brokers: [bootstrapServer],
-            ssl: true,
-            sasl: {
-                // TODO add oauth
-                mechanism: 'plain',
-                username: username,
-                password: password,
-            },
-            logLevel: logLevel.INFO
-          })
-    }
+  constructor(bootstrapServer: string, username: string, password: string) {
+    this.bootstrapServer = bootstrapServer;
+    this.username = username;
+    this.password = password;
+    this.kafka = new Kafka({
+      brokers: [bootstrapServer],
+      ssl: true,
+      sasl: {
+        // TODO add oauth
+        mechanism: 'plain',
+        username: username,
+        password: password
+      },
+      logLevel: logLevel.INFO
+    });
+  }
 }
 
 export class KafkaProducer extends KafkaClient {
-    
-    private producer: Producer
+  private producer: Producer;
 
-    constructor(bootstrapServer: string, username: string, password: string) {
-        super(bootstrapServer, username, password)
-        this.producer = this.kafka.producer()
-    }
+  constructor(bootstrapServer: string, username: string, password: string) {
+    super(bootstrapServer, username, password);
+    this.producer = this.kafka.producer();
+  }
 
-    async produceMessages(topicName: string, messageCount: number, key: string) {
-        await this.producer.connect()
-        
-        const messages = this.generateMessages(messageCount, key)
-        return await this.producer
-            .send({
-                topic: topicName,
-                messages: messages,
-                acks: -1,
-            })
-            .then(response => {
-                this.kafka.logger().info(`Messages sent #${response}`, {
-                response,
-                messageCount,
-                })
-                return true  
-            })
-            .catch(e => {
-                this.kafka.logger().error(`[${KafkaProducer.name}] ${e.message}`, { stack: e.stack })
-                return e;
-            })
-    }
+  async produceMessages(topicName: string, messageCount: number, key: string) {
+    await this.producer.connect();
 
-    private generateMessage(key: String) {
-        return {
-            key: `key-${key}`,
-            value: `value-${key}-${new Date().toISOString()}`,
-        }
-    }
+    const messages = this.generateMessages(messageCount, key);
+    return await this.producer
+      .send({
+        topic: topicName,
+        messages: messages,
+        acks: -1
+      })
+      .then((response) => {
+        this.kafka.logger().info(`Messages sent #${response}`, {
+          response,
+          messageCount
+        });
+        return true;
+      })
+      .catch((e) => {
+        this.kafka.logger().error(`[${KafkaProducer.name}] ${e.message}`, { stack: e.stack });
+        return e;
+      });
+  }
 
-    private generateMessages(messageCount: number, key: string) {
-        return Array(messageCount)
-            .fill(this.generateMessage(key))
-    }
+  private generateMessage(key: String) {
+    return {
+      key: `key-${key}`,
+      value: `value-${key}-${new Date().toISOString()}`
+    };
+  }
+
+  private generateMessages(messageCount: number, key: string) {
+    return Array(messageCount).fill(this.generateMessage(key));
+  }
 }
 
 export class KafkaConsumer extends KafkaClient {
+  private kafkaConsumer: Consumer;
 
-    private kafkaConsumer: Consumer
+  constructor(bootstrapServer: string, consumerGroup: string, username: string, password: string) {
+    super(bootstrapServer, username, password);
+    this.kafkaConsumer = this.kafka.consumer({ groupId: consumerGroup });
+  }
 
-    constructor(bootstrapServer: string, consumerGroup: string, username: string, password: string) {
-        super(bootstrapServer, username, password)
-        this.kafkaConsumer = this.kafka.consumer({ groupId: consumerGroup })
-    }
+  public async consumeMessages(
+    topic: string,
+    expectedMsgCount: number,
+    fromBeginning: boolean = true
+  ): Promise<boolean> {
+    let msgCount = 0;
 
-    public async consumeMessages(topic: string, expectedMsgCount: number, fromBeginning: boolean = true): Promise<boolean> {   
-        let msgCount = 0;
+    try {
+      await this.kafkaConsumer.connect();
+      await this.kafkaConsumer.subscribe({ topic: topic, fromBeginning: fromBeginning });
 
-        try {
-            await this.kafkaConsumer.connect()
-            await this.kafkaConsumer.subscribe({ topic: topic, fromBeginning: fromBeginning })
-        
-            await this.kafkaConsumer.run({
-                eachMessage: async (messagePayload: EachMessagePayload) => {
-                    const { topic, partition, message } = messagePayload
-                    const prefix = `${topic}[${partition} | ${message.offset}] / ${message.timestamp}`
-                    console.log(`- ${prefix} ${message.key}#${message.value} -> ${msgCount}`)
-                    msgCount++
-                }
-            })
-        } catch (error) {
-            console.log('Error: ', error)
-            return error
+      await this.kafkaConsumer.run({
+        eachMessage: async (messagePayload: EachMessagePayload) => {
+          const { topic, partition, message } = messagePayload;
+          const prefix = `${topic}[${partition} | ${message.offset}] / ${message.timestamp}`;
+          console.log(`- ${prefix} ${message.key}#${message.value} -> ${msgCount}`);
+          msgCount++;
         }
+      });
+    } catch (error) {
+      console.log('Error: ', error);
+      return error;
+    }
 
-        return await new Promise((resolve, reject) => {
-            setTimeout(() => {
-                if (msgCount <= expectedMsgCount) {
-                    console.log("Received: " + msgCount)
-                    resolve(true)
-                } else {
-                    reject(false)
-                }
-            }, 20000)
-        }) 
-    }
-    
-    public async shutdown(): Promise<void> {
-        await this.kafkaConsumer.disconnect()
-    }
+    return await new Promise((resolve, reject) => {
+      setTimeout(() => {
+        if (msgCount <= expectedMsgCount) {
+          console.log('Received: ' + msgCount);
+          resolve(true);
+        } else {
+          reject(false);
+        }
+      }, 20000);
+    });
+  }
+
+  public async shutdown(): Promise<void> {
+    await this.kafkaConsumer.disconnect();
+  }
 }
-

--- a/lib/config.ts
+++ b/lib/config.ts
@@ -5,6 +5,7 @@ class Config {
   readonly password: string;
   readonly startingPage: string;
   readonly sessionID: string;
+  readonly instanceName: string;
 
   readonly kafkaInstanceCreationTimeout: number;
   readonly kafkaInstanceDeletionTimeout: number;
@@ -20,6 +21,10 @@ class Config {
     this.password = process.env.TEST_PASSWORD;
     this.startingPage = process.env.STARTING_PAGE || 'https://console.redhat.com';
     this.sessionID = uuid().substring(0, 16);
+    this.instanceName = process.env.INSTANCE_NAME;
+    if (this.instanceName == undefined) {
+      this.instanceName = `test-instance-${this.sessionID}`;
+    }
 
     this.kafkaInstanceCreationTimeout = 20 * 60 * 1000; // 20 minutes
     this.kafkaInstanceDeletionTimeout = 10 * 60 * 1000; // 10 minutes

--- a/lib/config.ts
+++ b/lib/config.ts
@@ -16,10 +16,12 @@ class Config {
   readonly serviceAccountCreationTimeout: number;
   readonly serviceAccountDeletionTimeout: number;
 
+  readonly startingPageDefault = 'https://console.redhat.com';
+
   constructor() {
     this.username = process.env.TEST_USERNAME;
     this.password = process.env.TEST_PASSWORD;
-    this.startingPage = process.env.STARTING_PAGE || 'https://console.redhat.com';
+    this.startingPage = process.env.STARTING_PAGE || this.startingPageDefault;
     this.sessionID = uuid().substring(0, 16);
     this.instanceName = process.env.INSTANCE_NAME;
     if (this.instanceName == undefined) {

--- a/lib/kafka.ts
+++ b/lib/kafka.ts
@@ -13,7 +13,7 @@ export const navigateToKafkaList = async function (page: Page) {
   await closePopUp(page, '[aria-label=close-notification]');
 
   await page.locator('[data-testid=router-link]', { hasText: 'Kafka Instances' }).click();
-  await expect((await page.locator('h1', { hasText: 'Kafka Instances' }))).toHaveCount(1);
+  await expect(await page.locator('h1', { hasText: 'Kafka Instances' })).toHaveCount(1);
 };
 
 export const createKafkaInstance = async function (page: Page, name: string, check = true) {

--- a/lib/kafka.ts
+++ b/lib/kafka.ts
@@ -13,7 +13,7 @@ export const navigateToKafkaList = async function (page: Page) {
   await closePopUp(page, '[aria-label=close-notification]');
 
   await page.locator('[data-testid=router-link]', { hasText: 'Kafka Instances' }).click();
-  expect((await page.locator('heading', { hasText: 'Kafka Instances' }).count()) === 1);
+  await expect((await page.locator('heading', { hasText: 'Kafka Instances' }).count()) === 1).toBeTruthy();
 };
 
 export const createKafkaInstance = async function (page: Page, name: string, check = true) {

--- a/lib/kafka.ts
+++ b/lib/kafka.ts
@@ -15,15 +15,8 @@ export const navigateToStreamsForApachaeKafka = async function (page: Page) {
 };
 
 export const navigateToKafkaList = async function (page: Page) {
-  navigateToApplicationAndDataServices(page);
-  navigateToStreamsForApachaeKafka(page);
-
-  // if (!(await page.locator('[data-testid=router-link]', { hasText: 'Kafka Instances' }).isVisible())) {
-  //   if (!(await page.locator('button', { hasText: 'Streams for Apache Kafka' }).isVisible())) {
-  //     await page.getByRole('link', { name: 'Application and Data Services' }).click();
-  //   }
-  //   await page.locator('button', { hasText: 'Streams for Apache Kafka' }).click();
-  // }
+  await navigateToApplicationAndDataServices(page);
+  await navigateToStreamsForApachaeKafka(page);
 
   await closePopUp(page);
 

--- a/lib/kafka.ts
+++ b/lib/kafka.ts
@@ -3,16 +3,16 @@ import { config } from './config';
 import { closePopUp } from './popup';
 
 export const navigateToKafkaList = async function (page: Page) {
-  if ((await page.locator('button', { hasText: 'Streams for Apache Kafka' }).count()) === 0) {
-    await page.getByRole('link', { name: 'Application and Data Services' }).click();
+  if (!(await page.locator('[data-testid=router-link]', { hasText: 'Kafka Instances' }).isVisible())) {
+    if (!(await page.locator('button', { hasText: 'Streams for Apache Kafka' }).isVisible())) {
+      await page.getByRole('link', { name: 'Application and Data Services' }).click();
+    }
+    await page.locator('button', { hasText: 'Streams for Apache Kafka' }).click();
   }
-
-  await page.locator('button', { hasText: 'Streams for Apache Kafka' }).click();
 
   await closePopUp(page, '[aria-label=close-notification]');
 
-  // await expect(await page.getByRole('link', { name: 'Kafka Instances' })).toHaveCount(1);
-  await page.locator('a', { hasText: 'Kafka Instances' }).click();
+  await page.locator('[data-testid=router-link]', { hasText: 'Kafka Instances' }).click();
   expect((await page.locator('heading', { hasText: 'Kafka Instances' }).count()) === 1);
 };
 
@@ -156,10 +156,11 @@ export const grantConsumerAccess = async function (page: Page, saId: string, top
 };
 
 export const navigateToAccess = async function (page: Page, kafkaName: string) {
-  if ((await page.locator('a', { hasText: 'Kafka Instances' }).count()) !== 1) {
-    await page.locator('button', { hasText: 'Streams for Apache Kafka' }).click();
-  }
-  await page.locator('a', { hasText: 'Kafka Instances' }).click();
+  // if ((await page.locator('a', { hasText: 'Kafka Instances' }).count()) !== 1) {
+  //   await page.locator('button', { hasText: 'Streams for Apache Kafka' }).click();
+  // }
+  // await page.locator('a', { hasText: 'Kafka Instances' }).click();
+  await navigateToKafkaList(page);
   await expect(page.getByText(kafkaName)).toHaveCount(1);
   await page.getByText(kafkaName).click();
   await page.getByTestId('pageKafka-tabPermissions').click();

--- a/lib/kafka.ts
+++ b/lib/kafka.ts
@@ -10,7 +10,7 @@ export const navigateToKafkaList = async function (page: Page) {
     await page.locator('button', { hasText: 'Streams for Apache Kafka' }).click();
   }
 
-  await closePopUp(page, '[aria-label=close-notification]');
+  await closePopUp(page);
 
   await page.locator('[data-testid=router-link]', { hasText: 'Kafka Instances' }).click();
   await expect(await page.locator('h1', { hasText: 'Kafka Instances' })).toHaveCount(1);

--- a/lib/kafka.ts
+++ b/lib/kafka.ts
@@ -4,19 +4,19 @@ import { closePopUp } from './popup';
 
 export const navigateToApplicationAndDataServices = async function (page: Page) {
   if (!(await page.locator('button', { hasText: 'Streams for Apache Kafka' }).isVisible())) {
-    await page.getByRole('link', { name: 'Application and Data Services' }).click()
+    await page.getByRole('link', { name: 'Application and Data Services' }).click();
   }
-}
+};
 
 export const navigateToStreamsForApachaeKafka = async function (page: Page) {
   if (!(await page.locator('[data-testid=router-link]', { hasText: 'Kafka Instances' }).isVisible())) {
     await page.locator('button', { hasText: 'Streams for Apache Kafka' }).click();
   }
-}
+};
 
 export const navigateToKafkaList = async function (page: Page) {
-  navigateToApplicationAndDataServices(page)
-  navigateToStreamsForApachaeKafka(page)
+  navigateToApplicationAndDataServices(page);
+  navigateToStreamsForApachaeKafka(page);
 
   // if (!(await page.locator('[data-testid=router-link]', { hasText: 'Kafka Instances' }).isVisible())) {
   //   if (!(await page.locator('button', { hasText: 'Streams for Apache Kafka' }).isVisible())) {

--- a/lib/kafka.ts
+++ b/lib/kafka.ts
@@ -13,7 +13,7 @@ export const navigateToKafkaList = async function (page: Page) {
   await closePopUp(page, '[aria-label=close-notification]');
 
   await page.locator('[data-testid=router-link]', { hasText: 'Kafka Instances' }).click();
-  await expect((await page.locator('heading', { hasText: 'Kafka Instances' }).count()) === 1).toBeTruthy();
+  await expect((await page.locator('h1', { hasText: 'Kafka Instances' }))).toHaveCount(1);
 };
 
 export const createKafkaInstance = async function (page: Page, name: string, check = true) {

--- a/lib/kafka.ts
+++ b/lib/kafka.ts
@@ -122,7 +122,7 @@ export const grantProducerAccess = async function (page: Page, saId: string, top
 
   await page.getByPlaceholder('Enter prefix').click();
   await page.getByPlaceholder('Enter prefix').fill(topicName);
-  // TODO - This is just a workaround - create issue for `save` button which is disabled even if the prefix is written
+  // TODO - This is just a workaround - `save` button is disabled even if the prefix is written but not confirmed by another action
   await page.getByPlaceholder('Enter prefix').click();
 
   await page.getByRole('button').filter({ hasText: 'Save' }).click();

--- a/lib/kafka.ts
+++ b/lib/kafka.ts
@@ -156,10 +156,6 @@ export const grantConsumerAccess = async function (page: Page, saId: string, top
 };
 
 export const navigateToAccess = async function (page: Page, kafkaName: string) {
-  // if ((await page.locator('a', { hasText: 'Kafka Instances' }).count()) !== 1) {
-  //   await page.locator('button', { hasText: 'Streams for Apache Kafka' }).click();
-  // }
-  // await page.locator('a', { hasText: 'Kafka Instances' }).click();
   await navigateToKafkaList(page);
   await expect(page.getByText(kafkaName)).toHaveCount(1);
   await page.getByText(kafkaName).click();

--- a/lib/kafka.ts
+++ b/lib/kafka.ts
@@ -2,13 +2,28 @@ import { expect, Page } from '@playwright/test';
 import { config } from './config';
 import { closePopUp } from './popup';
 
-export const navigateToKafkaList = async function (page: Page) {
+export const navigateToApplicationAndDataServices = async function (page: Page) {
+  if (!(await page.locator('button', { hasText: 'Streams for Apache Kafka' }).isVisible())) {
+    await page.getByRole('link', { name: 'Application and Data Services' }).click()
+  }
+}
+
+export const navigateToStreamsForApachaeKafka = async function (page: Page) {
   if (!(await page.locator('[data-testid=router-link]', { hasText: 'Kafka Instances' }).isVisible())) {
-    if (!(await page.locator('button', { hasText: 'Streams for Apache Kafka' }).isVisible())) {
-      await page.getByRole('link', { name: 'Application and Data Services' }).click();
-    }
     await page.locator('button', { hasText: 'Streams for Apache Kafka' }).click();
   }
+}
+
+export const navigateToKafkaList = async function (page: Page) {
+  navigateToApplicationAndDataServices(page)
+  navigateToStreamsForApachaeKafka(page)
+
+  // if (!(await page.locator('[data-testid=router-link]', { hasText: 'Kafka Instances' }).isVisible())) {
+  //   if (!(await page.locator('button', { hasText: 'Streams for Apache Kafka' }).isVisible())) {
+  //     await page.getByRole('link', { name: 'Application and Data Services' }).click();
+  //   }
+  //   await page.locator('button', { hasText: 'Streams for Apache Kafka' }).click();
+  // }
 
   await closePopUp(page);
 

--- a/lib/kafka.ts
+++ b/lib/kafka.ts
@@ -3,17 +3,17 @@ import { config } from './config';
 import { closePopUp } from './popup';
 
 export const navigateToKafkaList = async function (page: Page) {
-  if (await page.locator('button', { hasText: 'Streams for Apache Kafka' }).count() === 0) {
+  if ((await page.locator('button', { hasText: 'Streams for Apache Kafka' }).count()) === 0) {
     await page.getByRole('link', { name: 'Application and Data Services' }).click();
   }
 
   await page.locator('button', { hasText: 'Streams for Apache Kafka' }).click();
 
-  await closePopUp(page, '[aria-label=close-notification]')
+  await closePopUp(page, '[aria-label=close-notification]');
 
   // await expect(await page.getByRole('link', { name: 'Kafka Instances' })).toHaveCount(1);
   await page.locator('a', { hasText: 'Kafka Instances' }).click();
-  expect(await page.locator('heading', { hasText: 'Kafka Instances' }).count() === 1);
+  expect((await page.locator('heading', { hasText: 'Kafka Instances' }).count()) === 1);
 };
 
 export const createKafkaInstance = async function (page: Page, name: string, check = true) {
@@ -78,7 +78,7 @@ export const waitForKafkaReady = async function (page: Page, name: string) {
 };
 
 export const getBootstrapUrl = async function (page: Page, name: string) {
-  await navigateToKafkaList(page)
+  await navigateToKafkaList(page);
   const instanceLinkSelector = page.getByText(name);
   const row = page.locator('tr', { has: instanceLinkSelector });
   await row.locator('[aria-label="Actions"]').click();
@@ -90,14 +90,14 @@ export const getBootstrapUrl = async function (page: Page, name: string) {
   await page.locator('[aria-label="Close drawer panel"]').click();
 
   return bootstrap;
-}
-  
+};
+
 // TODO - we shouldn't use just prefix for topic/group but also complete name
 // TODO - we should click on topic name/prefix when it popups when filling the prefix/name
 export const grantProducerAccess = async function (page: Page, saId: string, topicName: string) {
   await page.getByTestId('actionManagePermissions').click();
   await page.getByRole('button', { name: 'Options menu' }).click();
-  await page.getByRole('option').filter({hasText: saId}).click();
+  await page.getByRole('option').filter({ hasText: saId }).click();
   await page.getByRole('button', { name: 'Next' }).click();
   await page.getByTestId('permissions-dropdown-toggle').click();
   // TODO - This is another option which should be tested
@@ -110,27 +110,26 @@ export const grantProducerAccess = async function (page: Page, saId: string, top
   // TODO - This is just a workaround - create issue for `save` button which is disabled even if the prefix is written
   await page.getByPlaceholder('Enter prefix').click();
 
-
-  await page.getByRole('button').filter({hasText: 'Save'}).click();
-}
+  await page.getByRole('button').filter({ hasText: 'Save' }).click();
+};
 
 // TODO - we shouldn't use just prefix for topic/group but also complete name
 // TODO - we should click on topic name/prefix when it popups when filling the prefix/name
 export const grantConsumerAccess = async function (page: Page, saId: string, topicName: string, consumerGroup: string) {
   await page.getByTestId('actionManagePermissions').click();
   await page.getByRole('button', { name: 'Options menu' }).click();
-  await page.getByRole('option').filter({hasText: saId}).click();
+  await page.getByRole('option').filter({ hasText: saId }).click();
   await page.getByRole('button', { name: 'Next' }).click();
   await page.getByTestId('permissions-dropdown-toggle').click();
 
   await page.locator('button', { hasText: 'Consume from a topic' }).click();
 
   await page
-  .getByRole('row', {
-    name: 'T Topic Options menu permission.manage_permissions_dialog.assign_permissions.resource_name_aria Options menu Label group category'
-  })
-  .getByPlaceholder('Enter prefix')
-  .click();
+    .getByRole('row', {
+      name: 'T Topic Options menu permission.manage_permissions_dialog.assign_permissions.resource_name_aria Options menu Label group category'
+    })
+    .getByPlaceholder('Enter prefix')
+    .click();
 
   await page
     .getByRole('row', {
@@ -153,14 +152,14 @@ export const grantConsumerAccess = async function (page: Page, saId: string, top
     .getByPlaceholder('Enter prefix')
     .fill(consumerGroup);
 
-    await page.getByRole('button').filter({hasText: 'Save'}).click();
-  }
+  await page.getByRole('button').filter({ hasText: 'Save' }).click();
+};
 
 export const navigateToAccess = async function (page: Page, kafkaName: string) {
-  if (await page.locator('a', { hasText: "Kafka Instances" }).count() !== 1) {
-    await page.locator('button', { hasText: "Streams for Apache Kafka" }).click();
+  if ((await page.locator('a', { hasText: 'Kafka Instances' }).count()) !== 1) {
+    await page.locator('button', { hasText: 'Streams for Apache Kafka' }).click();
   }
-  await page.locator('a', { hasText: "Kafka Instances" }).click();
+  await page.locator('a', { hasText: 'Kafka Instances' }).click();
   await expect(page.getByText(kafkaName)).toHaveCount(1);
   await page.getByText(kafkaName).click();
   await page.getByTestId('pageKafka-tabPermissions').click();
@@ -169,4 +168,3 @@ export const navigateToAccess = async function (page: Page, kafkaName: string) {
 export const navigateToConsumerGroups = async function (page: Page) {
   await page.getByTestId('pageKafka-tabConsumers').click();
 };
-

--- a/lib/popup.ts
+++ b/lib/popup.ts
@@ -1,0 +1,13 @@
+import { expect, Page } from "@playwright/test";
+
+export const closePopUp = async function (page: Page, selector: string) {
+    if (await page.locator(selector).count() !== 0) {
+      let popUpLocator = page.locator(selector)
+      let count = await popUpLocator.count();
+      while (count > 0) {
+          await popUpLocator.nth(0).click()
+          await expect(popUpLocator).toHaveCount(count - 1);
+          count--;
+      }
+    }
+  }

--- a/lib/popup.ts
+++ b/lib/popup.ts
@@ -1,13 +1,13 @@
-import { expect, Page } from "@playwright/test";
+import { expect, Page } from '@playwright/test';
 
 export const closePopUp = async function (page: Page, selector: string) {
-    if (await page.locator(selector).count() !== 0) {
-      let popUpLocator = page.locator(selector)
-      let count = await popUpLocator.count();
-      while (count > 0) {
-          await popUpLocator.nth(0).click()
-          await expect(popUpLocator).toHaveCount(count - 1);
-          count--;
-      }
+  if ((await page.locator(selector).count()) !== 0) {
+    let popUpLocator = page.locator(selector);
+    let count = await popUpLocator.count();
+    while (count > 0) {
+      await popUpLocator.nth(0).click();
+      await expect(popUpLocator).toHaveCount(count - 1);
+      count--;
     }
   }
+};

--- a/lib/popup.ts
+++ b/lib/popup.ts
@@ -1,7 +1,7 @@
 import { expect, Page } from '@playwright/test';
 
 export const closePopUp = async function (page: Page) {
-  let selector = '[aria-label=close-notification]';
+  const selector = '[aria-label=close-notification]';
   try {
     await expect(page.locator(selector)).toHaveCount(0);
   } catch (e) {

--- a/lib/popup.ts
+++ b/lib/popup.ts
@@ -2,15 +2,6 @@ import { expect, Page } from '@playwright/test';
 
 export const closePopUp = async function (page: Page) {
   let selector = '[aria-label=close-notification]';
-  // if ((await page.locator(selector).count()) !== 0) {
-  //   const popUpLocator = page.locator(selector);
-  //   let count = await popUpLocator.count();
-  //   while (count > 0) {
-  //     await popUpLocator.nth(0).click();
-  //     await expect(popUpLocator).toHaveCount(count - 1);
-  //     count--;
-  //   }
-  // }
   try {
     await expect(page.locator(selector)).toHaveCount(0);
   } catch (e) {

--- a/lib/popup.ts
+++ b/lib/popup.ts
@@ -5,7 +5,7 @@ export const closePopUp = async function (page: Page) {
   try {
     await expect(page.locator(selector)).toHaveCount(0);
   } catch (e) {
-    await page.locator(selector).nth(0).click();
+    await page.locator(selector).nth(0).click({ timeout: 5000 });
     await closePopUp(page);
   }
 };

--- a/lib/popup.ts
+++ b/lib/popup.ts
@@ -1,13 +1,20 @@
 import { expect, Page } from '@playwright/test';
 
-export const closePopUp = async function (page: Page, selector: string) {
-  if ((await page.locator(selector).count()) !== 0) {
-    const popUpLocator = page.locator(selector);
-    let count = await popUpLocator.count();
-    while (count > 0) {
-      await popUpLocator.nth(0).click();
-      await expect(popUpLocator).toHaveCount(count - 1);
-      count--;
-    }
+export const closePopUp = async function (page: Page) {
+  let selector = '[aria-label=close-notification]';
+  // if ((await page.locator(selector).count()) !== 0) {
+  //   const popUpLocator = page.locator(selector);
+  //   let count = await popUpLocator.count();
+  //   while (count > 0) {
+  //     await popUpLocator.nth(0).click();
+  //     await expect(popUpLocator).toHaveCount(count - 1);
+  //     count--;
+  //   }
+  // }
+  try {
+    await expect(page.locator(selector)).toHaveCount(0);
+  } catch (e) {
+    await page.locator(selector).nth(0).click();
+    await closePopUp(page);
   }
 };

--- a/lib/popup.ts
+++ b/lib/popup.ts
@@ -2,7 +2,7 @@ import { expect, Page } from '@playwright/test';
 
 export const closePopUp = async function (page: Page, selector: string) {
   if ((await page.locator(selector).count()) !== 0) {
-    let popUpLocator = page.locator(selector);
+    const popUpLocator = page.locator(selector);
     let count = await popUpLocator.count();
     while (count > 0) {
       await popUpLocator.nth(0).click();

--- a/lib/sa.ts
+++ b/lib/sa.ts
@@ -4,7 +4,6 @@ import { closePopUp } from './popup';
 
 export const navigateToSAList = async function (page: Page) {
   if ((await page.getByRole('link', { name: 'Application and Data Services' }).count()) === 1) {
-    // await page.locator('li >> a:has-text("Application and Data Services")').click();
     await page.getByRole('link', { name: 'Application and Data Services' }).click();
   }
   await closePopUp(page);

--- a/lib/sa.ts
+++ b/lib/sa.ts
@@ -4,12 +4,15 @@ import { closePopUp } from './popup';
 
 export const navigateToSAList = async function (page: Page) {
   if ((await page.getByRole('link', { name: 'Application and Data Services' }).count()) === 1) {
+    // await page.locator('li >> a:has-text("Application and Data Services")').click();
     await page.getByRole('link', { name: 'Application and Data Services' }).click();
   }
   await closePopUp(page, '[aria-label=close-notification]');
 
-  await page.getByRole('link').filter({ hasText: 'Service Accounts' }).click();
-  await expect(page.getByRole('heading', { name: 'Service Accounts' })).toHaveCount(1);
+  await expect(page.locator('li >> a:text("Service Accounts")')).toHaveCount(1);
+  await page.locator('li >> a:text("Service Accounts")').click();
+  // expect(await page.locator('h1:has-text("Service Accounts")').count() === 1).toBeTruthy();
+  await expect(page.locator('h1', { hasText: 'Service Accounts' })).toHaveCount(1);
 };
 
 export const createServiceAccount = async function (page: Page, name: string) {

--- a/lib/sa.ts
+++ b/lib/sa.ts
@@ -7,11 +7,10 @@ export const navigateToSAList = async function (page: Page) {
     // await page.locator('li >> a:has-text("Application and Data Services")').click();
     await page.getByRole('link', { name: 'Application and Data Services' }).click();
   }
-  await closePopUp(page, '[aria-label=close-notification]');
+  await closePopUp(page);
 
   await expect(page.locator('li >> a:text("Service Accounts")')).toHaveCount(1);
   await page.locator('li >> a:text("Service Accounts")').click();
-  // expect(await page.locator('h1:has-text("Service Accounts")').count() === 1).toBeTruthy();
   await expect(page.locator('h1', { hasText: 'Service Accounts' })).toHaveCount(1);
 };
 

--- a/lib/sa.ts
+++ b/lib/sa.ts
@@ -1,11 +1,15 @@
-import { expect, Page } from '@playwright/test';
-import { config } from './config';
+import { expect, Page } from "@playwright/test";
+import { config } from "./config";
+import { closePopUp } from "./popup";
 
 export const navigateToSAList = async function (page: Page) {
-  await page.getByRole('link', { name: 'Application and Data Services' }).click();
-  // }
-  await page.getByRole('link', { name: 'Service Accounts' }).click();
-  await expect(page.getByRole('heading', { name: 'Service Accounts' })).toHaveCount(1);
+    if (await page.getByRole('link', { name: 'Application and Data Services' }).count() === 1) {
+        await page.getByRole('link', { name: 'Application and Data Services' }).click();
+    } 
+    await closePopUp(page, '[aria-label=close-notification]')
+    
+    await page.getByRole('link').filter({ hasText: 'Service Accounts' }).click();
+    await expect(page.getByRole('heading', { name: 'Service Accounts' })).toHaveCount(1);
 };
 
 export const createServiceAccount = async function (page: Page, name: string) {

--- a/lib/sa.ts
+++ b/lib/sa.ts
@@ -1,15 +1,15 @@
-import { expect, Page } from "@playwright/test";
-import { config } from "./config";
-import { closePopUp } from "./popup";
+import { expect, Page } from '@playwright/test';
+import { config } from './config';
+import { closePopUp } from './popup';
 
 export const navigateToSAList = async function (page: Page) {
-    if (await page.getByRole('link', { name: 'Application and Data Services' }).count() === 1) {
-        await page.getByRole('link', { name: 'Application and Data Services' }).click();
-    } 
-    await closePopUp(page, '[aria-label=close-notification]')
-    
-    await page.getByRole('link').filter({ hasText: 'Service Accounts' }).click();
-    await expect(page.getByRole('heading', { name: 'Service Accounts' })).toHaveCount(1);
+  if ((await page.getByRole('link', { name: 'Application and Data Services' }).count()) === 1) {
+    await page.getByRole('link', { name: 'Application and Data Services' }).click();
+  }
+  await closePopUp(page, '[aria-label=close-notification]');
+
+  await page.getByRole('link').filter({ hasText: 'Service Accounts' }).click();
+  await expect(page.getByRole('heading', { name: 'Service Accounts' })).toHaveCount(1);
 };
 
 export const createServiceAccount = async function (page: Page, name: string) {

--- a/lib/topic.ts
+++ b/lib/topic.ts
@@ -5,7 +5,7 @@ export const navigateToKafkaTopicsList = async function (page: Page, kafkaName: 
   await expect(page.getByText(kafkaName)).toHaveCount(1);
   await waitForKafkaReady(page, kafkaName);
   await page.locator('a', { hasText: kafkaName }).click();
-  expect((await page.locator('button', { hasText: 'Topics' }).count()) == 1);
+  await expect((await page.locator('button', { hasText: 'Topics' }).count()) == 1).toBeTruthy();
   // data-testid=pageKafka-tabTopics
   await page.locator('button', { hasText: 'Topics' }).click();
 };
@@ -39,10 +39,10 @@ export const deleteKafkaTopic = async function (page: Page, name: string) {
 export const navigeToMessages = async function (page: Page, kafkaName: string, topicName: string) {
   await navigateToKafkaList(page);
   await navigateToKafkaTopicsList(page, kafkaName);
-  expect((await page.locator('a', { hasText: topicName }).count()) !== 0);
+  await expect((await page.locator('a', { hasText: topicName }).count()) !== 0).toBeTruthy();
   await page.locator('a', { hasText: topicName }).click();
 
-  expect((await page.locator('button', { hasText: 'Messages' }).count()) !== 0);
+  await expect((await page.locator('button', { hasText: 'Messages' }).count()) !== 0).toBeTruthy();
 
   await page.locator('button', { hasText: 'Messages' }).click();
 

--- a/lib/topic.ts
+++ b/lib/topic.ts
@@ -39,7 +39,6 @@ export const deleteKafkaTopic = async function (page: Page, name: string) {
 export const navigeToMessages = async function (page: Page, kafkaName: string, topicName: string) {
   await navigateToKafkaList(page);
   await navigateToKafkaTopicsList(page, kafkaName);
-  // await expect((await page.locator('a', { hasText: topicName }).count()) !== 0).toBeTruthy();
   await expect(await page.locator('a', { hasText: topicName })).toHaveCount(1);
 
   await page.locator('a', { hasText: topicName }).click();

--- a/lib/topic.ts
+++ b/lib/topic.ts
@@ -52,4 +52,8 @@ export const navigeToMessages = async function (page: Page, kafkaName: string, t
   if (await page.locator('button:has-text("Check for new data")').isVisible()) {
     await page.locator('button:has-text("Check for new data")').click();
   }
+  // TODO deal with this, put it to some for or something
+  if (await page.locator('button:has-text("Check for new data")').isVisible()) {
+    await page.locator('button:has-text("Check for new data")').click();
+  }
 };

--- a/lib/topic.ts
+++ b/lib/topic.ts
@@ -50,9 +50,9 @@ export const navigeToMessages = async function (page: Page, kafkaName: string, t
 
 export const refreshMessages = async function (page: Page) {
   try {
-    await expect(page.locator('table[aria-label="Messages table"]')).toHaveCount(1)
+    await expect(page.locator('table[aria-label="Messages table"]')).toHaveCount(1);
   } catch (e) {
-    await page.locator('button', { hasText: "Check for new data" }).click();
-    refreshMessages(page)
+    await page.locator('button', { hasText: 'Check for new data' }).click();
+    refreshMessages(page);
   }
-}
+};

--- a/lib/topic.ts
+++ b/lib/topic.ts
@@ -47,4 +47,8 @@ export const navigeToMessages = async function (page: Page, kafkaName: string, t
   await page.locator('button', { hasText: 'Messages' }).click();
 
   await expect(page.locator('table', { hasText: 'Messages table' })).toBeTruthy();
+
+  if (await page.locator('button:has-text("Check for new data")').isVisible()) {
+    await page.locator('button:has-text("Check for new data")').click();
+  }
 };

--- a/lib/topic.ts
+++ b/lib/topic.ts
@@ -1,5 +1,5 @@
 import { expect, Page } from '@playwright/test';
-import { waitForKafkaReady } from './kafka';
+import { navigateToKafkaList, waitForKafkaReady } from './kafka';
 
 export const navigateToKafkaTopicsList = async function (page: Page, kafkaName: string) {
   await expect(page.getByText(kafkaName)).toHaveCount(1);
@@ -34,4 +34,17 @@ export const deleteKafkaTopic = async function (page: Page, name: string) {
   // data-testid=modalDeleteTopic-buttonDelete
   await page.locator('button', { hasText: 'Delete' }).click();
   await expect(page.getByText(name)).toHaveCount(0);
+};
+
+export const navigeToMessages = async function (page: Page, kafkaName: string, topicName: string) {
+  await navigateToKafkaList(page);
+  await navigateToKafkaTopicsList(page, kafkaName);
+  expect((await page.locator('a', { hasText: topicName }).count()) !== 0);
+  await page.locator('a', { hasText: topicName }).click();
+
+  expect((await page.locator('button', { hasText: 'Messages' }).count()) !== 0);
+
+  await page.locator('button', { hasText: 'Messages' }).click();
+
+  await expect(page.locator('table', { hasText: 'Messages table' })).toBeTruthy();
 };

--- a/lib/topic.ts
+++ b/lib/topic.ts
@@ -46,14 +46,13 @@ export const navigeToMessages = async function (page: Page, kafkaName: string, t
   await expect(await page.locator('button', { hasText: 'Messages' })).toHaveCount(1);
 
   await page.locator('button', { hasText: 'Messages' }).click();
-
-  await expect(page.locator('table', { hasText: 'Messages table' })).toBeTruthy();
-
-  if (await page.locator('button:has-text("Check for new data")').isVisible()) {
-    await page.locator('button:has-text("Check for new data")').click();
-  }
-  // TODO deal with this, put it to some for or something
-  if (await page.locator('button:has-text("Check for new data")').isVisible()) {
-    await page.locator('button:has-text("Check for new data")').click();
-  }
 };
+
+export const refreshMessages = async function (page: Page) {
+  try {
+    await expect(page.locator('table[aria-label="Messages table"]')).toHaveCount(1)
+  } catch (e) {
+    await page.locator('button', { hasText: "Check for new data" }).click();
+    refreshMessages(page)
+  }
+}

--- a/lib/topic.ts
+++ b/lib/topic.ts
@@ -5,7 +5,7 @@ export const navigateToKafkaTopicsList = async function (page: Page, kafkaName: 
   await expect(page.getByText(kafkaName)).toHaveCount(1);
   await waitForKafkaReady(page, kafkaName);
   await page.locator('a', { hasText: kafkaName }).click();
-  expect(await page.locator('button', { hasText: 'Topics' }).count() == 1);
+  expect((await page.locator('button', { hasText: 'Topics' }).count()) == 1);
   // data-testid=pageKafka-tabTopics
   await page.locator('button', { hasText: 'Topics' }).click();
 };

--- a/lib/topic.ts
+++ b/lib/topic.ts
@@ -5,6 +5,7 @@ export const navigateToKafkaTopicsList = async function (page: Page, kafkaName: 
   await expect(page.getByText(kafkaName)).toHaveCount(1);
   await waitForKafkaReady(page, kafkaName);
   await page.locator('a', { hasText: kafkaName }).click();
+  expect(await page.locator('button', { hasText: 'Topics' }).count() == 1);
   // data-testid=pageKafka-tabTopics
   await page.locator('button', { hasText: 'Topics' }).click();
 };

--- a/lib/topic.ts
+++ b/lib/topic.ts
@@ -5,9 +5,9 @@ export const navigateToKafkaTopicsList = async function (page: Page, kafkaName: 
   await expect(page.getByText(kafkaName)).toHaveCount(1);
   await waitForKafkaReady(page, kafkaName);
   await page.locator('a', { hasText: kafkaName }).click();
-  await expect((await page.locator('button', { hasText: 'Topics' }).count()) == 1).toBeTruthy();
+  await expect(await page.locator('button[aria-label="Topics"]')).toHaveCount(1);
   // data-testid=pageKafka-tabTopics
-  await page.locator('button', { hasText: 'Topics' }).click();
+  await page.locator('button[aria-label="Topics"]').click();
 };
 
 export const createKafkaTopic = async function (page: Page, name: string) {
@@ -39,10 +39,12 @@ export const deleteKafkaTopic = async function (page: Page, name: string) {
 export const navigeToMessages = async function (page: Page, kafkaName: string, topicName: string) {
   await navigateToKafkaList(page);
   await navigateToKafkaTopicsList(page, kafkaName);
-  await expect((await page.locator('a', { hasText: topicName }).count()) !== 0).toBeTruthy();
+  // await expect((await page.locator('a', { hasText: topicName }).count()) !== 0).toBeTruthy();
+  await expect(await page.locator('a', { hasText: topicName })).toHaveCount(1);
+
   await page.locator('a', { hasText: topicName }).click();
 
-  await expect((await page.locator('button', { hasText: 'Messages' }).count()) !== 0).toBeTruthy();
+  await expect(await page.locator('button', { hasText: 'Messages' })).toHaveCount(1);
 
   await page.locator('button', { hasText: 'Messages' }).click();
 

--- a/lib/topic.ts
+++ b/lib/topic.ts
@@ -36,7 +36,7 @@ export const deleteKafkaTopic = async function (page: Page, name: string) {
   await expect(page.getByText(name)).toHaveCount(0);
 };
 
-export const navigeToMessages = async function (page: Page, kafkaName: string, topicName: string) {
+export const navigateToMessages = async function (page: Page, kafkaName: string, topicName: string) {
   await navigateToKafkaList(page);
   await navigateToKafkaTopicsList(page, kafkaName);
   await expect(await page.locator('a', { hasText: topicName })).toHaveCount(1);
@@ -52,7 +52,7 @@ export const refreshMessages = async function (page: Page) {
   try {
     await expect(page.locator('table[aria-label="Messages table"]')).toHaveCount(1);
   } catch (e) {
-    await page.locator('button', { hasText: 'Check for new data' }).click();
-    refreshMessages(page);
+    await page.locator('button', { hasText: 'Check for new data' }).click({ timeout: 5000 });
+    await refreshMessages(page);
   }
 };

--- a/tests/kas.spec.ts
+++ b/tests/kas.spec.ts
@@ -70,7 +70,7 @@ const filterByStatus = async function (page, status) {
 };
 
 // test_3kas.py test_kas_kafka_filter_by_status
-test('test Kafka list filtered by status', async ({ page }) => {
+test.skip('test Kafka list filtered by status', async ({ page }) => {
   const testInstanceName = `test-instance-${config.sessionID}`;
 
   await createKafkaInstance(page, testInstanceName);
@@ -104,7 +104,7 @@ test('test Kafka list filtered by status', async ({ page }) => {
 
 // test_3kas.py test_try_to_create_kafka_instance_with_same_name
 // NOTE: this test is expected to be pretty fragile as it needs that the current instance is in "early" `Creating` status
-test('test fail to create Kafka instance with the same name', async ({ page }) => {
+test.skip('test fail to create Kafka instance with the same name', async ({ page }) => {
   const testInstanceName = `test-instance-${config.sessionID}`;
   await createKafkaInstance(page, testInstanceName, false);
 

--- a/tests/kas.spec.ts
+++ b/tests/kas.spec.ts
@@ -89,8 +89,8 @@ test('test Kafka list filtered by status', async ({ page }) => {
 
   // TODO: Probably race condition when deleting is finished too quickly
   // Currently it just make the test flaky so we should discuss what we will do with it
-  // await filterByStatus(page, 'Deleting');
-  // await expect(page.getByText(testInstanceName)).toBeTruthy();
+  await filterByStatus(page, 'Deleting');
+  await expect(page.getByText(testInstanceName)).toBeTruthy();
 
   // await for the kafka instance to be deleted
   await expect(page.getByText(`${testInstanceName}`, { exact: true })).toHaveCount(0, {

--- a/tests/kas.spec.ts
+++ b/tests/kas.spec.ts
@@ -3,13 +3,15 @@ import login from '@lib/auth';
 import { config } from '@lib/config';
 import { navigateToKafkaList, deleteKafkaInstance, createKafkaInstance, waitForKafkaReady } from '@lib/kafka';
 
+const testInstanceName = config.instanceName;
+
 test.beforeEach(async ({ page }) => {
   await login(page);
 
   await navigateToKafkaList(page);
 
   await page.waitForSelector('[role=progressbar]', { state: 'detached', timeout: config.kafkaInstanceCreationTimeout });
-
+  await page.waitForSelector('button:has-text("Create Kafka Instance")');
   for (const el of await page.locator(`tr >> a`).elementHandles()) {
     const name = await el.textContent();
     await deleteKafkaInstance(page, name);
@@ -23,16 +25,12 @@ test('check there are no Kafka instances', async ({ page }) => {
 
 // test_3kas.py test_kas_kafka_create_dont_wait_for_ready_delete_wait_for_delete
 test('create and delete a Kafka instance', async ({ page }) => {
-  const testInstanceName = `test-instance-${config.sessionID}`;
-
   await createKafkaInstance(page, testInstanceName);
   await deleteKafkaInstance(page, testInstanceName);
 });
 
 // test_3kas.py test_kas_kafka_create_wait_for_ready_delete_wait_for_delete
 test('create, wait for ready and delete a Kafka instance', async ({ page }) => {
-  const testInstanceName = `test-instance-${config.sessionID}`;
-
   await createKafkaInstance(page, testInstanceName);
   await waitForKafkaReady(page, testInstanceName);
   await deleteKafkaInstance(page, testInstanceName);
@@ -70,9 +68,7 @@ const filterByStatus = async function (page, status) {
 };
 
 // test_3kas.py test_kas_kafka_filter_by_status
-test.skip('test Kafka list filtered by status', async ({ page }) => {
-  const testInstanceName = `test-instance-${config.sessionID}`;
-
+test('test Kafka list filtered by status', async ({ page }) => {
   await createKafkaInstance(page, testInstanceName);
   await expect(page.getByText(testInstanceName)).toBeVisible();
 
@@ -93,8 +89,8 @@ test.skip('test Kafka list filtered by status', async ({ page }) => {
 
   // TODO: Probably race condition when deleting is finished too quickly
   // Currently it just make the test flaky so we should discuss what we will do with it
-  await filterByStatus(page, 'Deleting');
-  await expect(page.getByText(testInstanceName)).toBeTruthy();
+  // await filterByStatus(page, 'Deleting');
+  // await expect(page.getByText(testInstanceName)).toBeTruthy();
 
   // await for the kafka instance to be deleted
   await expect(page.getByText(`${testInstanceName}`, { exact: true })).toHaveCount(0, {
@@ -104,8 +100,7 @@ test.skip('test Kafka list filtered by status', async ({ page }) => {
 
 // test_3kas.py test_try_to_create_kafka_instance_with_same_name
 // NOTE: this test is expected to be pretty fragile as it needs that the current instance is in "early" `Creating` status
-test.skip('test fail to create Kafka instance with the same name', async ({ page }) => {
-  const testInstanceName = `test-instance-${config.sessionID}`;
+test('test fail to create Kafka instance with the same name', async ({ page }) => {
   await createKafkaInstance(page, testInstanceName, false);
 
   await page.getByText('Create Kafka instance').click();

--- a/tests/kas_messaging.spec.ts
+++ b/tests/kas_messaging.spec.ts
@@ -16,11 +16,11 @@ import { KafkaConsumer, KafkaProducer } from '../lib/clients';
 import { strict as assert } from 'assert';
 import { createServiceAccount, deleteServiceAccount, navigateToSAList } from '@lib/sa';
 
-const testInstanceName = config.instanceName;
-const testTopicName = `test-jstejska`;
-const testServiceAccountName = 'jstejska-test';
+const testInstanceName = "test-instance-messaging";
+const testTopicName = `test-topic-name`;
+const testServiceAccountName = 'test-service-account';
 const testMessageKey = 'key';
-const consumerGroupId = 'test';
+const consumerGroupId = 'test-consumer-group';
 const expectedMessageCount = 100;
 let credentials;
 let bootstrap: string;
@@ -32,7 +32,7 @@ test.beforeEach(async ({ page }) => {
 
   await expect(page.getByRole('button', { name: 'Create Kafka instance' })).toBeVisible();
 
-  if ((await page.getByText(testInstanceName).count()) > 0 && (await page.locator('tr').count()) === 2) {
+  if ((await page.  getByText(testInstanceName).count()) > 0 && (await page.locator('tr').count()) === 2) {
     // Test instance present, nothing to do!
   } else {
     await page.waitForSelector('[role=progressbar]', {
@@ -89,7 +89,7 @@ test('Consume messages from topic', async ({ page }) => {
 
   // Open Consumer Groups Tab to check dashboard
   await navigateToConsumerGroups(page);
-  await expect((await page.getByText(consumerGroupId).count()) >= 1).toBeTruthy();
+  await expect(await page.getByText(consumerGroupId)).toHaveCount(1);
   // Shutdown consumer
   await consumer.shutdown();
 });

--- a/tests/kas_messaging.spec.ts
+++ b/tests/kas_messaging.spec.ts
@@ -1,0 +1,98 @@
+import { test, expect } from '@playwright/test';
+import login from '@lib/auth';
+import { config } from '@lib/config';
+import { navigateToKafkaList, deleteKafkaInstance, createKafkaInstance, getBootstrapUrl, navigateToAccess, manageAccess, navigateToConsumerGroups, grantProducerAccess, grantConsumerAccess } from '@lib/kafka';
+import { navigateToKafkaTopicsList, createKafkaTopic, deleteKafkaTopic } from '@lib/topic';
+import { KafkaConsumer, KafkaProducer } from '../lib/clients'
+import { strict as assert } from 'assert';
+import { createServiceAccount, deleteServiceAccount, navigateToSAList } from '@lib/sa';
+
+// const testInstanceName = `test-instance-${config.sessionID}`;
+// const testTopicName = `test-topic-${config.sessionID}`;
+
+const testInstanceName = `jakub-test`;
+const testTopicName = `test-jstejska`;
+const testServiceAccountName = "jstejska-test";
+let credentials;
+
+test.beforeEach(async ({ page }) => {
+  await login(page);
+
+  await navigateToKafkaList(page);
+
+  await expect(page.getByRole('button', { name: 'Create Kafka instance' })).toBeVisible();
+
+  if ((await page.getByText(testInstanceName).count()) > 0 && (await page.locator('tr').count()) === 2) {
+    // Test instance present, nothing to do!
+  } else {
+    await page.waitForSelector('[role=progressbar]', {
+      state: 'detached',
+      timeout: config.kafkaInstanceCreationTimeout
+    });
+
+    for (const el of await page.locator(`tr >> a`).elementHandles()) {
+      const name = await el.textContent();
+
+      if (name !== testInstanceName) {
+        await deleteKafkaInstance(page, name);
+      }
+    }
+
+    if ((await page.getByText(testInstanceName).count()) === 0) {
+      await createKafkaInstance(page, testInstanceName);
+    }
+  }
+
+  await navigateToKafkaTopicsList(page, testInstanceName);
+  // Do not create topic if it already exists
+  await expect(page.getByText('Create topic')).toHaveCount(1);
+  if ((await page.locator('a', { hasText: testTopicName }).count()) === 0) {
+    await createKafkaTopic(page, testTopicName);
+  }
+
+  await navigateToSAList(page)
+  await expect(page.getByText('Create service account')).toHaveCount(1);
+  if ((await page.locator('tr', { hasText: testServiceAccountName }).count()) !== 0 ) {
+    await deleteServiceAccount(page, testServiceAccountName)
+  }
+  credentials = await createServiceAccount(page, testServiceAccountName)
+
+});
+
+// test_6messages.py generate_messages_to_topic
+test('Generate messages to topic', async({ page }) => {
+  const consumerGroupId = "test"
+  const expectedMessageCount = 100
+
+  const bootstrap = await getBootstrapUrl(page, testInstanceName)
+
+  await navigateToAccess(page, testInstanceName);
+  await grantProducerAccess(page, credentials.clientID, testTopicName);
+  await grantConsumerAccess(page, credentials.clientID, testTopicName, consumerGroupId);
+
+  // Producer 100 messages
+  const producer = new KafkaProducer(bootstrap, credentials.clientID, credentials.clientSecret)
+  let producerResponse = await producer.produceMessages(testTopicName, expectedMessageCount, "key")
+  assert(producerResponse === true)
+
+  // Consume 100 messages
+  const consumer = new KafkaConsumer(bootstrap, consumerGroupId, credentials.clientID, credentials.clientSecret)
+  let consumerResponse = await consumer.consumeMessages(testTopicName, expectedMessageCount)
+  assert(consumerResponse === true)
+
+  // Open Consumer Groups Tab to check dashboard
+  await navigateToConsumerGroups(page);
+  expect(await page.getByText(consumerGroupId).count() >= 1);
+  // Shutdown producer
+  await consumer.shutdown()
+})
+
+// // test_6messages.py browse_messages
+// test('Browse messages', async({page}) => {
+//   await navigeToMessages(page, testTopicName)
+// })
+
+// // test_6messages.py filter_messages
+// test('Filter messages', async({page}) => {
+//   await navigeToMessages(page, testTopicName)
+// })

--- a/tests/kas_messaging.spec.ts
+++ b/tests/kas_messaging.spec.ts
@@ -25,6 +25,8 @@ let credentials;
 let bootstrap: string;
 
 test.beforeEach(async ({ page }) => {
+  test.skip(config.startingPage === config.startingPageDefault);
+
   await login(page);
 
   await navigateToKafkaList(page);

--- a/tests/kas_messaging.spec.ts
+++ b/tests/kas_messaging.spec.ts
@@ -50,30 +50,30 @@ test.beforeEach(async ({ page }) => {
     if ((await page.getByText(testInstanceName).count()) === 0) {
       await createKafkaInstance(page, testInstanceName);
     }
-
-    await navigateToKafkaTopicsList(page, testInstanceName);
-    // Do not create topic if it already exists
-    await expect(page.getByText('Create topic')).toHaveCount(1);
-    if ((await page.locator('a', { hasText: testTopicName }).count()) === 0) {
-      await createKafkaTopic(page, testTopicName);
-    }
-
-    await navigateToSAList(page);
-    await expect(page.getByText('Create service account')).toHaveCount(1);
-    if ((await page.locator('tr', { hasText: testServiceAccountName }).count()) !== 0) {
-      await deleteServiceAccount(page, testServiceAccountName);
-    }
-    credentials = await createServiceAccount(page, testServiceAccountName);
-    bootstrap = await getBootstrapUrl(page, testInstanceName);
-
-    await navigateToAccess(page, testInstanceName);
-    await grantProducerAccess(page, credentials.clientID, testTopicName);
-
-    // Producer 100 messages
-    const producer = new KafkaProducer(bootstrap, credentials.clientID, credentials.clientSecret);
-    const producerResponse = await producer.produceMessages(testTopicName, expectedMessageCount, testMessageKey);
-    expect(producerResponse === true);
   }
+
+  await navigateToKafkaTopicsList(page, testInstanceName);
+  // Do not create topic if it already exists
+  await expect(page.getByText('Create topic')).toHaveCount(1);
+  if ((await page.locator('a', { hasText: testTopicName }).count()) === 0) {
+    await createKafkaTopic(page, testTopicName);
+  }
+
+  await navigateToSAList(page);
+  await expect(page.getByText('Create service account')).toHaveCount(1);
+  if ((await page.locator('tr', { hasText: testServiceAccountName }).count()) !== 0) {
+    await deleteServiceAccount(page, testServiceAccountName);
+  }
+  credentials = await createServiceAccount(page, testServiceAccountName);
+  bootstrap = await getBootstrapUrl(page, testInstanceName);
+
+  await navigateToAccess(page, testInstanceName);
+  await grantProducerAccess(page, credentials.clientID, testTopicName);
+
+  // Producer 100 messages
+  const producer = new KafkaProducer(bootstrap, credentials.clientID, credentials.clientSecret);
+  const producerResponse = await producer.produceMessages(testTopicName, expectedMessageCount, testMessageKey);
+  expect(producerResponse === true).toBeTruthy();
 });
 
 // test_6messages.py generate_messages_to_topic
@@ -84,7 +84,7 @@ test('Consume messages from topic', async ({ page }) => {
   // Consume 100 messages
   const consumer = new KafkaConsumer(bootstrap, consumerGroupId, credentials.clientID, credentials.clientSecret);
   const consumerResponse = await consumer.consumeMessages(testTopicName, expectedMessageCount);
-  expect(consumerResponse >= expectedMessageCount);
+  expect(consumerResponse).toBeGreaterThanOrEqual(expectedMessageCount);
 
   // Open Consumer Groups Tab to check dashboard
   await navigateToConsumerGroups(page);
@@ -96,10 +96,6 @@ test('Consume messages from topic', async ({ page }) => {
 // test_6messages.py browse_messages
 test('Browse messages', async ({ page }) => {
   await navigeToMessages(page, testInstanceName, testTopicName);
-
-  if (await page.locator('button:has-text("Check for new data")').isVisible()) {
-    await page.locator('button:has-text("Check for new data")').click();
-  }
 
   await expect(page.locator('table[aria-label="Messages table"]')).toContainText('value-' + testMessageKey);
   await expect(page.locator('table[aria-label="Messages table"]')).toContainText('key-' + testMessageKey);

--- a/tests/kas_messaging.spec.ts
+++ b/tests/kas_messaging.spec.ts
@@ -13,7 +13,6 @@ import {
 } from '@lib/kafka';
 import { navigateToKafkaTopicsList, createKafkaTopic, navigeToMessages } from '@lib/topic';
 import { KafkaConsumer, KafkaProducer } from '@lib/clients';
-import { strict as assert } from 'assert';
 import { createServiceAccount, deleteServiceAccount, navigateToSAList } from '@lib/sa';
 
 const testInstanceName = 'test-instance-messaging';
@@ -73,7 +72,7 @@ test.beforeEach(async ({ page }) => {
     // Producer 100 messages
     const producer = new KafkaProducer(bootstrap, credentials.clientID, credentials.clientSecret);
     const producerResponse = await producer.produceMessages(testTopicName, expectedMessageCount, testMessageKey);
-    assert(producerResponse === true);
+    expect(producerResponse === true);
   }
 });
 
@@ -85,7 +84,7 @@ test('Consume messages from topic', async ({ page }) => {
   // Consume 100 messages
   const consumer = new KafkaConsumer(bootstrap, consumerGroupId, credentials.clientID, credentials.clientSecret);
   const consumerResponse = await consumer.consumeMessages(testTopicName, expectedMessageCount);
-  assert(consumerResponse === true);
+  expect(consumerResponse >= expectedMessageCount);
 
   // Open Consumer Groups Tab to check dashboard
   await navigateToConsumerGroups(page);
@@ -97,6 +96,10 @@ test('Consume messages from topic', async ({ page }) => {
 // test_6messages.py browse_messages
 test('Browse messages', async ({ page }) => {
   await navigeToMessages(page, testInstanceName, testTopicName);
+
+  if (await page.locator('button:has-text("Check for new data")').isVisible()) {
+    await page.locator('button:has-text("Check for new data")').click();
+  }
 
   await expect(page.locator('table[aria-label="Messages table"]')).toContainText('value-' + testMessageKey);
   await expect(page.locator('table[aria-label="Messages table"]')).toContainText('key-' + testMessageKey);

--- a/tests/kas_messaging.spec.ts
+++ b/tests/kas_messaging.spec.ts
@@ -12,7 +12,7 @@ import {
   grantConsumerAccess
 } from '@lib/kafka';
 import { navigateToKafkaTopicsList, createKafkaTopic, navigeToMessages } from '@lib/topic';
-import { KafkaConsumer, KafkaProducer } from '../lib/clients';
+import { KafkaConsumer, KafkaProducer } from '@lib/clients';
 import { strict as assert } from 'assert';
 import { createServiceAccount, deleteServiceAccount, navigateToSAList } from '@lib/sa';
 

--- a/tests/kas_messaging.spec.ts
+++ b/tests/kas_messaging.spec.ts
@@ -11,7 +11,7 @@ import {
   grantProducerAccess,
   grantConsumerAccess
 } from '@lib/kafka';
-import { navigateToKafkaTopicsList, createKafkaTopic, navigeToMessages, refreshMessages } from '@lib/topic';
+import { navigateToKafkaTopicsList, createKafkaTopic, navigateToMessages, refreshMessages } from '@lib/topic';
 import { KafkaConsumer, KafkaProducer } from '@lib/clients';
 import { createServiceAccount, deleteServiceAccount, navigateToSAList } from '@lib/sa';
 
@@ -86,7 +86,7 @@ test('Consume messages from topic', async ({ page }) => {
   // Consume 100 messages
   const consumer = new KafkaConsumer(bootstrap, consumerGroupId, credentials.clientID, credentials.clientSecret);
   const consumerResponse = await consumer.consumeMessages(testTopicName, expectedMessageCount);
-  expect(consumerResponse).toBeGreaterThanOrEqual(expectedMessageCount);
+  expect(consumerResponse).toEqual(expectedMessageCount);
 
   // Open Consumer Groups Tab to check dashboard
   await navigateToConsumerGroups(page);
@@ -97,7 +97,7 @@ test('Consume messages from topic', async ({ page }) => {
 
 // test_6messages.py browse_messages
 test('Browse messages', async ({ page }) => {
-  await navigeToMessages(page, testInstanceName, testTopicName);
+  await navigateToMessages(page, testInstanceName, testTopicName);
 
   await refreshMessages(page);
 

--- a/tests/kas_messaging.spec.ts
+++ b/tests/kas_messaging.spec.ts
@@ -25,6 +25,7 @@ let credentials;
 let bootstrap: string;
 
 test.beforeEach(async ({ page }) => {
+  // @ts-ignore
   test.skip(config.startingPage === config.startingPageDefault);
 
   await login(page);

--- a/tests/kas_messaging.spec.ts
+++ b/tests/kas_messaging.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect, Page } from '@playwright/test';
+import { test, expect } from '@playwright/test';
 import login from '@lib/auth';
 import { config } from '@lib/config';
 import {
@@ -11,7 +11,7 @@ import {
   grantProducerAccess,
   grantConsumerAccess
 } from '@lib/kafka';
-import { navigateToKafkaTopicsList, createKafkaTopic, deleteKafkaTopic, navigeToMessages } from '@lib/topic';
+import { navigateToKafkaTopicsList, createKafkaTopic, navigeToMessages } from '@lib/topic';
 import { KafkaConsumer, KafkaProducer } from '../lib/clients';
 import { strict as assert } from 'assert';
 import { createServiceAccount, deleteServiceAccount, navigateToSAList } from '@lib/sa';
@@ -89,7 +89,7 @@ test('Consume messages from topic', async ({ page }) => {
 
   // Open Consumer Groups Tab to check dashboard
   await navigateToConsumerGroups(page);
-  expect((await page.getByText(consumerGroupId).count()) >= 1);
+  await expect((await page.getByText(consumerGroupId).count()) >= 1).toBeTruthy();
   // Shutdown consumer
   await consumer.shutdown();
 });
@@ -106,8 +106,8 @@ test('Browse messages', async ({ page }) => {
   await expect(page.locator('table[aria-label="Messages table"]')).toContainText('key-' + testMessageKey);
   await page.locator('table[aria-label="Messages table"] >> tr').nth(1).click();
   const messageDetail = await page.locator('data-testid=message-details');
-  expect(messageDetail.locator('dt:has-text("Offset")')).toHaveCount(1);
-  expect(messageDetail.locator('dd:has-text("key-")')).toHaveCount(1);
+  await expect(messageDetail.locator('dt:has-text("Offset")')).toHaveCount(1);
+  await expect(messageDetail.locator('dd:has-text("key-")')).toHaveCount(1);
 });
 
 // test_6messages.py filter_messages

--- a/tests/kas_messaging.spec.ts
+++ b/tests/kas_messaging.spec.ts
@@ -105,4 +105,3 @@ test('Browse messages', async ({ page }) => {
   await expect(messageDetail.locator('dt:has-text("Offset")')).toHaveCount(1);
   await expect(messageDetail.locator('dd:has-text("key-")')).toHaveCount(1);
 });
-

--- a/tests/kas_messaging.spec.ts
+++ b/tests/kas_messaging.spec.ts
@@ -91,8 +91,6 @@ test('Consume messages from topic', async ({ page }) => {
   // Open Consumer Groups Tab to check dashboard
   await navigateToConsumerGroups(page);
   await expect(await page.getByText(consumerGroupId)).toHaveCount(1);
-  // Shutdown consumer
-  await consumer.shutdown();
 });
 
 // test_6messages.py browse_messages

--- a/tests/kas_messaging.spec.ts
+++ b/tests/kas_messaging.spec.ts
@@ -73,7 +73,7 @@ test.beforeEach(async ({ page }) => {
 
   // Producer 100 messages
   const producer = new KafkaProducer(bootstrap, credentials.clientID, credentials.clientSecret);
-  let producerResponse = await producer.produceMessages(testTopicName, expectedMessageCount, testMessageKey);
+  const producerResponse = await producer.produceMessages(testTopicName, expectedMessageCount, testMessageKey);
   assert(producerResponse === true);
 });
 
@@ -84,7 +84,7 @@ test('Consume messages from topic', async ({ page }) => {
 
   // Consume 100 messages
   const consumer = new KafkaConsumer(bootstrap, consumerGroupId, credentials.clientID, credentials.clientSecret);
-  let consumerResponse = await consumer.consumeMessages(testTopicName, expectedMessageCount);
+  const consumerResponse = await consumer.consumeMessages(testTopicName, expectedMessageCount);
   assert(consumerResponse === true);
 
   // Open Consumer Groups Tab to check dashboard

--- a/tests/kas_messaging.spec.ts
+++ b/tests/kas_messaging.spec.ts
@@ -25,7 +25,6 @@ let credentials;
 let bootstrap: string;
 
 test.beforeEach(async ({ page }) => {
-  // @ts-ignore
   test.skip(config.startingPage === config.startingPageDefault);
 
   await login(page);

--- a/tests/kas_messaging.spec.ts
+++ b/tests/kas_messaging.spec.ts
@@ -97,7 +97,7 @@ test('Consume messages from topic', async ({ page }) => {
 test('Browse messages', async ({ page }) => {
   await navigeToMessages(page, testInstanceName, testTopicName);
 
-  await refreshMessages(page)
+  await refreshMessages(page);
 
   await expect(page.locator('table[aria-label="Messages table"]')).toContainText('value-' + testMessageKey);
   await expect(page.locator('table[aria-label="Messages table"]')).toContainText('key-' + testMessageKey);

--- a/tests/kas_messaging.spec.ts
+++ b/tests/kas_messaging.spec.ts
@@ -11,7 +11,7 @@ import {
   grantProducerAccess,
   grantConsumerAccess
 } from '@lib/kafka';
-import { navigateToKafkaTopicsList, createKafkaTopic, navigeToMessages } from '@lib/topic';
+import { navigateToKafkaTopicsList, createKafkaTopic, navigeToMessages, refreshMessages } from '@lib/topic';
 import { KafkaConsumer, KafkaProducer } from '@lib/clients';
 import { createServiceAccount, deleteServiceAccount, navigateToSAList } from '@lib/sa';
 
@@ -96,6 +96,8 @@ test('Consume messages from topic', async ({ page }) => {
 // test_6messages.py browse_messages
 test('Browse messages', async ({ page }) => {
   await navigeToMessages(page, testInstanceName, testTopicName);
+
+  await refreshMessages(page)
 
   await expect(page.locator('table[aria-label="Messages table"]')).toContainText('value-' + testMessageKey);
   await expect(page.locator('table[aria-label="Messages table"]')).toContainText('key-' + testMessageKey);

--- a/tests/kas_messaging.spec.ts
+++ b/tests/kas_messaging.spec.ts
@@ -1,9 +1,19 @@
 import { test, expect } from '@playwright/test';
 import login from '@lib/auth';
 import { config } from '@lib/config';
-import { navigateToKafkaList, deleteKafkaInstance, createKafkaInstance, getBootstrapUrl, navigateToAccess, manageAccess, navigateToConsumerGroups, grantProducerAccess, grantConsumerAccess } from '@lib/kafka';
+import {
+  navigateToKafkaList,
+  deleteKafkaInstance,
+  createKafkaInstance,
+  getBootstrapUrl,
+  navigateToAccess,
+  manageAccess,
+  navigateToConsumerGroups,
+  grantProducerAccess,
+  grantConsumerAccess
+} from '@lib/kafka';
 import { navigateToKafkaTopicsList, createKafkaTopic, deleteKafkaTopic } from '@lib/topic';
-import { KafkaConsumer, KafkaProducer } from '../lib/clients'
+import { KafkaConsumer, KafkaProducer } from '../lib/clients';
 import { strict as assert } from 'assert';
 import { createServiceAccount, deleteServiceAccount, navigateToSAList } from '@lib/sa';
 
@@ -12,7 +22,7 @@ import { createServiceAccount, deleteServiceAccount, navigateToSAList } from '@l
 
 const testInstanceName = `jakub-test`;
 const testTopicName = `test-jstejska`;
-const testServiceAccountName = "jstejska-test";
+const testServiceAccountName = 'jstejska-test';
 let credentials;
 
 test.beforeEach(async ({ page }) => {
@@ -50,42 +60,41 @@ test.beforeEach(async ({ page }) => {
     await createKafkaTopic(page, testTopicName);
   }
 
-  await navigateToSAList(page)
+  await navigateToSAList(page);
   await expect(page.getByText('Create service account')).toHaveCount(1);
-  if ((await page.locator('tr', { hasText: testServiceAccountName }).count()) !== 0 ) {
-    await deleteServiceAccount(page, testServiceAccountName)
+  if ((await page.locator('tr', { hasText: testServiceAccountName }).count()) !== 0) {
+    await deleteServiceAccount(page, testServiceAccountName);
   }
-  credentials = await createServiceAccount(page, testServiceAccountName)
-
+  credentials = await createServiceAccount(page, testServiceAccountName);
 });
 
 // test_6messages.py generate_messages_to_topic
-test('Generate messages to topic', async({ page }) => {
-  const consumerGroupId = "test"
-  const expectedMessageCount = 100
+test('Generate messages to topic', async ({ page }) => {
+  const consumerGroupId = 'test';
+  const expectedMessageCount = 100;
 
-  const bootstrap = await getBootstrapUrl(page, testInstanceName)
+  const bootstrap = await getBootstrapUrl(page, testInstanceName);
 
   await navigateToAccess(page, testInstanceName);
   await grantProducerAccess(page, credentials.clientID, testTopicName);
   await grantConsumerAccess(page, credentials.clientID, testTopicName, consumerGroupId);
 
   // Producer 100 messages
-  const producer = new KafkaProducer(bootstrap, credentials.clientID, credentials.clientSecret)
-  let producerResponse = await producer.produceMessages(testTopicName, expectedMessageCount, "key")
-  assert(producerResponse === true)
+  const producer = new KafkaProducer(bootstrap, credentials.clientID, credentials.clientSecret);
+  let producerResponse = await producer.produceMessages(testTopicName, expectedMessageCount, 'key');
+  assert(producerResponse === true);
 
   // Consume 100 messages
-  const consumer = new KafkaConsumer(bootstrap, consumerGroupId, credentials.clientID, credentials.clientSecret)
-  let consumerResponse = await consumer.consumeMessages(testTopicName, expectedMessageCount)
-  assert(consumerResponse === true)
+  const consumer = new KafkaConsumer(bootstrap, consumerGroupId, credentials.clientID, credentials.clientSecret);
+  let consumerResponse = await consumer.consumeMessages(testTopicName, expectedMessageCount);
+  assert(consumerResponse === true);
 
   // Open Consumer Groups Tab to check dashboard
   await navigateToConsumerGroups(page);
-  expect(await page.getByText(consumerGroupId).count() >= 1);
+  expect((await page.getByText(consumerGroupId).count()) >= 1);
   // Shutdown producer
-  await consumer.shutdown()
-})
+  await consumer.shutdown();
+});
 
 // // test_6messages.py browse_messages
 // test('Browse messages', async({page}) => {

--- a/tests/kas_messaging.spec.ts
+++ b/tests/kas_messaging.spec.ts
@@ -98,10 +98,6 @@ test('Consume messages from topic', async ({ page }) => {
 test('Browse messages', async ({ page }) => {
   await navigeToMessages(page, testInstanceName, testTopicName);
 
-  if (await page.locator('button:has-text("Check for new data")').isVisible()) {
-    await page.locator('button:has-text("Check for new data")').click();
-  }
-
   await expect(page.locator('table[aria-label="Messages table"]')).toContainText('value-' + testMessageKey);
   await expect(page.locator('table[aria-label="Messages table"]')).toContainText('key-' + testMessageKey);
   await page.locator('table[aria-label="Messages table"] >> tr').nth(1).click();
@@ -110,7 +106,3 @@ test('Browse messages', async ({ page }) => {
   await expect(messageDetail.locator('dd:has-text("key-")')).toHaveCount(1);
 });
 
-// test_6messages.py filter_messages
-test.skip('Filter messages', async ({ page }) => {
-  await navigeToMessages(page, testInstanceName, testTopicName);
-});

--- a/tests/kas_with_instance.spec.ts
+++ b/tests/kas_with_instance.spec.ts
@@ -3,11 +3,10 @@ import login from '@lib/auth';
 import { config } from '@lib/config';
 import { navigateToKafkaList, deleteKafkaInstance, createKafkaInstance, waitForKafkaReady } from '@lib/kafka';
 import { navigateToKafkaTopicsList, createKafkaTopic, deleteKafkaTopic } from '@lib/topic';
-import { KafkaConsumer, KafkaProducer } from '../lib/clients';
-import { strict as assert } from 'assert';
 
-const testInstanceName = `test-instance-${config.sessionID}`;
-const testTopicName = `test-topic-${config.sessionID}`;
+const testInstanceName = config.instanceName;
+const testTopicPrefix = 'test-topic-';
+const testTopicName = `${testTopicPrefix}${config.sessionID}`;
 
 test.beforeEach(async ({ page }) => {
   await login(page);
@@ -34,6 +33,7 @@ test.beforeEach(async ({ page }) => {
 
     if ((await page.getByText(testInstanceName).count()) === 0) {
       await createKafkaInstance(page, testInstanceName);
+      await waitForKafkaReady(page, testInstanceName);
     }
   }
 });

--- a/tests/kas_with_instance.spec.ts
+++ b/tests/kas_with_instance.spec.ts
@@ -3,8 +3,11 @@ import login from '@lib/auth';
 import { config } from '@lib/config';
 import { navigateToKafkaList, deleteKafkaInstance, createKafkaInstance, waitForKafkaReady } from '@lib/kafka';
 import { navigateToKafkaTopicsList, createKafkaTopic, deleteKafkaTopic } from '@lib/topic';
+import { KafkaConsumer, KafkaProducer } from '../lib/clients'
+import { strict as assert } from 'assert';
 
-const testInstanceName = `test-instance-${config.sessionID}`;
+// const testInstanceName = `test-instance-${config.sessionID}`;
+const testInstanceName = `jakub-test`;
 const testTopicName = `test-topic-${config.sessionID}`;
 
 test.beforeEach(async ({ page }) => {
@@ -176,3 +179,22 @@ test('create and delete a Kafka Topic', async ({ page }) => {
   await createKafkaTopic(page, testTopicName);
   await deleteKafkaTopic(page, testTopicName);
 });
+
+test('producer-sasl-plain-ssl', async() => {
+
+  let bootstrap: string = "jakub-test-ce-ko-nhuq-sola--qcg.bf2.kafka-stage.rhcloud.com:443"
+
+  const producer = new KafkaProducer("test", bootstrap)
+  let producerResponse = await producer.produceMessages("test", 100, "test")
+  console.log(producerResponse)
+
+  assert(producerResponse === true)
+
+  const consumer = new KafkaConsumer("test", bootstrap, "test")
+  let consumerResponse = await consumer.consumeMessages("test", "test", 100)
+  console.log(consumerResponse)
+
+  assert(consumerResponse === true)
+})
+
+

--- a/tests/kas_with_instance.spec.ts
+++ b/tests/kas_with_instance.spec.ts
@@ -3,7 +3,7 @@ import login from '@lib/auth';
 import { config } from '@lib/config';
 import { navigateToKafkaList, deleteKafkaInstance, createKafkaInstance, waitForKafkaReady } from '@lib/kafka';
 import { navigateToKafkaTopicsList, createKafkaTopic, deleteKafkaTopic } from '@lib/topic';
-import { KafkaConsumer, KafkaProducer } from '../lib/clients'
+import { KafkaConsumer, KafkaProducer } from '../lib/clients';
 import { strict as assert } from 'assert';
 
 const testInstanceName = `test-instance-${config.sessionID}`;
@@ -178,6 +178,3 @@ test('create and delete a Kafka Topic', async ({ page }) => {
   await createKafkaTopic(page, testTopicName);
   await deleteKafkaTopic(page, testTopicName);
 });
-
-
-

--- a/tests/kas_with_instance.spec.ts
+++ b/tests/kas_with_instance.spec.ts
@@ -6,8 +6,7 @@ import { navigateToKafkaTopicsList, createKafkaTopic, deleteKafkaTopic } from '@
 import { KafkaConsumer, KafkaProducer } from '../lib/clients'
 import { strict as assert } from 'assert';
 
-// const testInstanceName = `test-instance-${config.sessionID}`;
-const testInstanceName = `jakub-test`;
+const testInstanceName = `test-instance-${config.sessionID}`;
 const testTopicName = `test-topic-${config.sessionID}`;
 
 test.beforeEach(async ({ page }) => {
@@ -180,21 +179,5 @@ test('create and delete a Kafka Topic', async ({ page }) => {
   await deleteKafkaTopic(page, testTopicName);
 });
 
-test('producer-sasl-plain-ssl', async() => {
-
-  let bootstrap: string = "jakub-test-ce-ko-nhuq-sola--qcg.bf2.kafka-stage.rhcloud.com:443"
-
-  const producer = new KafkaProducer("test", bootstrap)
-  let producerResponse = await producer.produceMessages("test", 100, "test")
-  console.log(producerResponse)
-
-  assert(producerResponse === true)
-
-  const consumer = new KafkaConsumer("test", bootstrap, "test")
-  let consumerResponse = await consumer.consumeMessages("test", "test", 100)
-  console.log(consumerResponse)
-
-  assert(consumerResponse === true)
-})
 
 

--- a/tests/kas_with_instance.spec.ts
+++ b/tests/kas_with_instance.spec.ts
@@ -33,7 +33,6 @@ test.beforeEach(async ({ page }) => {
 
     if ((await page.getByText(testInstanceName).count()) === 0) {
       await createKafkaInstance(page, testInstanceName);
-      await waitForKafkaReady(page, testInstanceName);
     }
   }
 });

--- a/tests/sa.spec.ts
+++ b/tests/sa.spec.ts
@@ -3,7 +3,8 @@ import login from '@lib/auth';
 import { config } from '@lib/config';
 import { navigateToSAList, createServiceAccount, deleteServiceAccount, resetServiceAccount } from '@lib/sa';
 
-const testServiceAccountName = `test-service-account-${config.sessionID}`;
+const testServiceAccountPrefix = 'test-service-account-';
+const testServiceAccountName = `${testServiceAccountPrefix}${config.sessionID}`;
 
 test.beforeEach(async ({ page }) => {
   await login(page);
@@ -15,17 +16,11 @@ test.beforeEach(async ({ page }) => {
     timeout: config.serviceAccountCreationTimeout
   });
 
-  const elements = async () => {
-    return await (
-      await page.locator(`tr >> td[data-label="Description"]`).elementHandles()
-    ).length;
-  };
+  await deleteServiceAccount(page, testServiceAccountPrefix);
+});
 
-  while ((await elements()) > 0) {
-    const el = await page.locator(`tr >> td[data-label="Description"]`).nth(0);
-    const accountID = await el.textContent();
-    await deleteServiceAccount(page, accountID);
-  }
+test.afterAll(async ({ page }) => {
+  await deleteServiceAccount(page, testServiceAccountName);
 });
 
 // test_5sa.py test_sa_create


### PR DESCRIPTION
This PR adds kafkajs dependency and also simple implementation of blocking producer and consumer.

As part of this PR I also added two tests - one for producing/consuming messages from topic and one fro browse messages. Filtering will be done in the next PR.

This PR also contains several improvements/fixes for navigation to make the navigation reusable from multiple places and also more stable.

TODO - do not merge yet, still need to do final test