### PR TITLE
Locator fixes and other failures

### DIFF
--- a/tests/kas_with_instance.spec.ts
+++ b/tests/kas_with_instance.spec.ts
@@ -128,37 +128,31 @@ test('test instances can be filtered by cloud provider', async ({ page }) => {
 test('test instance details on row click', async ({ page }) => {
   await page.getByRole('gridcell', { name: `${config.username}` }).click();
 
-  await expect(page.getByRole('heading', { name: `${testInstanceName}` })).toHaveCount(1);
+  await expect(page.locator('h1', { hasText: `${testInstanceName}` })).toHaveCount(1);
 });
 
 // test_3kas.py test_kas_kafka_view_details_by_menu_click_panel_opened
-test('test instance details on instance name click', async ({ page }) => {
-  await page.getByRole('gridcell', { name: `${testInstanceName}` }).click();
+test('test instance details on menu click', async ({ page }) => {
+  await page.locator('main >> [aria-label="Actions"]').click();
+  await page.locator('button', { hasText: 'Details' }).click();
 
-  await expect(page.getByRole('heading', { name: `${testInstanceName}` })).toHaveCount(1);
-  await expect(page.getByTestId('pageKafka-tabDashboard')).toHaveCount(1);
+  await expect(page.locator('h1', { hasText: `${testInstanceName}` })).toHaveCount(1);
+  await expect(page.locator('button', { hasText: 'Details' })).toHaveCount(1);
+
+  await page.locator('button[aria-label="Close drawer panel"]').click();
 });
 
-// test_3kas.py test_kas_kafka_view_details_by_menu_click_panel_opened
 // test_3kas.py test_kas_kafka_view_details_by_connection_menu_click_panel_opened
 // ... and more ...
 test('test instance quick options', async ({ page }) => {
-  await page.getByRole('button', { name: 'Actions' }).click();
-  await page.getByRole('menuitem', { name: 'Details' }).click();
-
-  await expect(page.getByRole('heading', { name: `${testInstanceName}` })).toHaveCount(1);
-  await expect(page.getByRole('tab', { name: 'Details' })).toHaveCount(1);
-
-  await page.getByRole('button', { name: 'Close drawer panel' }).click();
-
-  await page.getByRole('button', { name: 'Actions' }).click();
-  await page.getByRole('menuitem', { name: 'Connection' }).click();
+  await page.locator('main >> [aria-label="Actions"]').click();
+  await page.locator('button', { hasText: 'Connection' }).click();
 
   await expect(page.getByRole('textbox', { name: 'Bootstrap server' })).toHaveCount(1);
 
-  await page.getByRole('button', { name: 'Close drawer panel' }).click();
+  await page.locator('button[aria-label="Close drawer panel"]').click();
 
-  await page.getByRole('button', { name: 'Actions' }).click();
+  await page.locator('main >> [aria-label="Actions"]').click();
   await page.getByRole('menuitem', { name: 'Change owner' }).click();
 
   await expect(page.getByText('Current owner')).toHaveCount(1);

--- a/tests/kas_with_instance.spec.ts
+++ b/tests/kas_with_instance.spec.ts
@@ -161,6 +161,14 @@ test('test instance quick options', async ({ page }) => {
   await page.getByRole('button', { name: 'Cancel' }).click();
 });
 
+// test_4kas.py test_kafka_dashboard_opened
+test('test instance dashboard on instance name click', async ({ page }) => {
+  await page.locator('a', { hasText: `${testInstanceName}` }).click();
+
+  await expect(page.locator('h1', { hasText: `${testInstanceName}` })).toHaveCount(1);
+  await expect(page.getByTestId('pageKafka-tabDashboard')).toHaveCount(1);
+});
+
 // test_4kafka.py test_kafka_topic_create
 test('create and delete a Kafka Topic', async ({ page }) => {
   await navigateToKafkaTopicsList(page, testInstanceName);


### PR DESCRIPTION
```
// test_3kas.py test_kas_kafka_view_details_by_menu_click_panel_opened
test('test instance details on instance name click', async ({ page }) => {
```
This test was not doing what the original IQE test was doing - test that you can open the details menu by clicking on the menu. Instead, it was opening the Kafka Instance dashboard, so I changed the test to do what it was supposed to and moved navigating to the dashboard to a new test.

Also, some changes to the locator, because they were not reliable and tests were constantly failing. `getByRole` seems to be quite unreliable, we should consider removing it completely from the test suite. Quite often it does not locate the element at all and does not do exact matching. Exact matching is added to it in Playwright v1.28 - we should upgrade the dependency.