### PR TITLE
UPDATE: Click on input text before typing

### DIFF
--- a/lib/kafka.ts
+++ b/lib/kafka.ts
@@ -34,7 +34,7 @@ export const deleteKafkaInstance = async function (page: Page, name: string, awa
   await page.locator('button', { hasText: 'Delete instance' }).click();
   try {
     await expect(page.locator('input[name="mas-name-input"]')).toHaveCount(1);
-
+    await page.locator('input[name="mas-name-input"]').click();
     // FIXME: workaround for https://github.com/redhat-developer/app-services-ui-components/issues/590
     // https://github.com/microsoft/playwright/issues/15734#issuecomment-1188245775
     await page.locator('input[name="mas-name-input"]').type(name, { delay: 200 });


### PR DESCRIPTION
Click on input text before typing as a user would do in order to prevent Playwright going too fast and missing starter characters