### PR TITLE
Add tests for filtering messages

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -5,6 +5,7 @@ module.exports = {
   plugins: ['@typescript-eslint'],
   rules: {
     "playwright/no-skipped-test": "off",
+    "playwright/no-conditional-in-test": "off"
   },
   root: true,
 };

--- a/lib/config.ts
+++ b/lib/config.ts
@@ -8,6 +8,8 @@ class Config {
   readonly startingPage: string;
   readonly sessionID: string;
   readonly instanceName: string;
+  readonly serviceAccount: string;
+  readonly testTopicName: string;
 
   readonly kafkaInstanceCreationTimeout: number;
   readonly kafkaInstanceDeletionTimeout: number;
@@ -34,6 +36,8 @@ class Config {
     if (this.instanceName == undefined) {
       this.instanceName = `test-instance-${this.sessionID}`;
     }
+    this.serviceAccount = `test-service-account-${this.sessionID}`;
+    this.testTopicName = `test-topic-${this.sessionID}`;
 
     // Timeouts
     this.kafkaInstanceCreationTimeout = 20 * 60 * 1000; // 20 minutes

--- a/lib/config.ts
+++ b/lib/config.ts
@@ -8,8 +8,6 @@ class Config {
   readonly startingPage: string;
   readonly sessionID: string;
   readonly instanceName: string;
-  readonly serviceAccount: string;
-  readonly testTopicName: string;
 
   readonly kafkaInstanceCreationTimeout: number;
   readonly kafkaInstanceDeletionTimeout: number;
@@ -36,9 +34,6 @@ class Config {
     if (this.instanceName == undefined) {
       this.instanceName = `test-instance-${this.sessionID}`;
     }
-    this.serviceAccount = `test-service-account-${this.sessionID}`;
-    this.testTopicName = `test-topic-${this.sessionID}`;
-
     // Timeouts
     this.kafkaInstanceCreationTimeout = 20 * 60 * 1000; // 20 minutes
     this.kafkaInstanceDeletionTimeout = 10 * 60 * 1000; // 10 minutes

--- a/lib/kafka.ts
+++ b/lib/kafka.ts
@@ -31,7 +31,7 @@ export const createKafkaInstance = async function (page: Page, name: string, che
 
   // FIXME: workaround for https://github.com/redhat-developer/app-services-ui-components/issues/590
   // https://github.com/microsoft/playwright/issues/15734#issuecomment-1188245775
-  await sleep(500)
+  await sleep(500);
   await page.getByLabel('Name *').click();
 
   await page.getByLabel('Name *').fill(name);

--- a/lib/kafka.ts
+++ b/lib/kafka.ts
@@ -122,8 +122,6 @@ export const grantProducerAccess = async function (page: Page, saId: string, top
   await page.getByPlaceholder('Enter prefix').click();
 
   await page.getByRole('button').filter({ hasText: 'Save' }).click();
-  //Sleep 5s to propagate changes
-  await sleep(5000);
 };
 
 // TODO - we shouldn't use just prefix for topic/group but also complete name
@@ -166,8 +164,6 @@ export const grantConsumerAccess = async function (page: Page, saId: string, top
     .fill(consumerGroup);
 
   await page.getByRole('button').filter({ hasText: 'Save' }).click();
-  //Sleep 5s to propagate changes
-  await sleep(5000);
 };
 
 export const navigateToAccess = async function (page: Page, kafkaName: string) {

--- a/lib/kafka.ts
+++ b/lib/kafka.ts
@@ -31,7 +31,7 @@ export const createKafkaInstance = async function (page: Page, name: string, che
 
   // FIXME: workaround for https://github.com/redhat-developer/app-services-ui-components/issues/590
   // https://github.com/microsoft/playwright/issues/15734#issuecomment-1188245775
-  await sleep(500);
+  await new Promise((resolve) => setTimeout(resolve, 500));
   await page.getByLabel('Name *').click();
 
   await page.getByLabel('Name *').fill(name);
@@ -122,6 +122,8 @@ export const grantProducerAccess = async function (page: Page, saId: string, top
   await page.getByPlaceholder('Enter prefix').click();
 
   await page.getByRole('button').filter({ hasText: 'Save' }).click();
+  //Sleep 5s to propagate changes
+  await sleep(5000);
 };
 
 // TODO - we shouldn't use just prefix for topic/group but also complete name
@@ -164,6 +166,8 @@ export const grantConsumerAccess = async function (page: Page, saId: string, top
     .fill(consumerGroup);
 
   await page.getByRole('button').filter({ hasText: 'Save' }).click();
+  //Sleep 5s to propagate changes
+  await sleep(5000);
 };
 
 export const navigateToAccess = async function (page: Page, kafkaName: string) {

--- a/lib/kafka.ts
+++ b/lib/kafka.ts
@@ -31,7 +31,7 @@ export const createKafkaInstance = async function (page: Page, name: string, che
 
   // FIXME: workaround for https://github.com/redhat-developer/app-services-ui-components/issues/590
   // https://github.com/microsoft/playwright/issues/15734#issuecomment-1188245775
-  await new Promise((resolve) => setTimeout(resolve, 500));
+  await sleep(500)
   await page.getByLabel('Name *').click();
 
   await page.getByLabel('Name *').fill(name);

--- a/lib/messages.ts
+++ b/lib/messages.ts
@@ -1,4 +1,4 @@
-import { expect, Page } from '@playwright/test';
+import { Page } from '@playwright/test';
 
 export enum Limit {
   ten = 10,
@@ -13,57 +13,40 @@ export enum FilterGroup {
   latest = 'Latest messages'
 }
 
-export const setPartition = async function (page: Page, partition: string) {
-  await page.locator('[aria-label="Specify partition value"]').click();
-  await page.locator('[aria-label="Specify partition value"]').fill(partition);
-};
-
 export const pickFilterOption = async function (page: Page, option: FilterGroup) {
   await page.locator('[data-testid="filter-group"]').click();
-  switch (option) {
-    case FilterGroup.offset: {
-      await page.locator('a:text-is("' + FilterGroup.offset + '")').click();
-      break;
-    }
-    case FilterGroup.timestamp: {
-      await page.locator('a:text-is("' + FilterGroup.timestamp + '")').click();
-      break;
-    }
-    case FilterGroup.epoch: {
-      await page.locator('a:text-is("' + FilterGroup.epoch + '")').click();
-      break;
-    }
-    case FilterGroup.latest: {
-      await page.locator('a:text-is("' + FilterGroup.latest + '")').click();
-      break;
-    }
-  }
+  await page.locator('a:text-is("' + option + '")').click();
 };
 
-export const setOffeset = async function (page: Page, offset: string) {
-  await page.locator('[aria-label="Specify offset"]').click();
-  await page.locator('[aria-label="Specify offset"]').fill(offset);
+const setField = async function (page: Page, locator: string, value: string) {
+  await page.locator(locator).click();
+  await page.locator(locator).fill(value);
+};
+
+export const setPartition = async function (page: Page, partition: string) {
+  await setField(page, '[aria-label="Specify partition value"]', partition);
+};
+
+export const setOffset = async function (page: Page, offset: string) {
+  await setField(page, '[aria-label="Specify offset"]', offset);
 };
 
 export const setTimestamp = async function (page: Page, timestamp: string) {
-  await page.locator('[aria-label="Date picker"]').click();
-  await page.locator('[aria-label="Date picker"]').fill(timestamp);
+  await setField(page, '[aria-label="Date picker"]', timestamp);
 };
 
 export const setEpoch = async function (page: Page, epochTimestamp: number) {
-  await page.locator('[aria-label="Specify epoch timestamp"]').click();
-  await page.locator('[aria-label="Specify epoch timestamp"]').fill(epochTimestamp.toString());
+  await setField(page, '[aria-label="Specify epoch timestamp"]', epochTimestamp.toString());
 };
 
 export const setLimit = async function (page: Page, limit: Limit) {
-  // TODO change 10 to number regex
-  await page.locator('button:has-text("10 messages")').click();
+  await page.locator('button >> text=/\\d+ messages/i').click();
   await page.locator('li >> button:has-text("' + limit + ' messages")').click();
 };
 
 export const filterMessagesByOffset = async function (page: Page, partition: string, offset: string, limit: Limit) {
   await setPartition(page, partition);
-  await setOffeset(page, offset);
+  await setOffset(page, offset);
   await setLimit(page, limit);
 
   await applyFilter(page);
@@ -71,14 +54,4 @@ export const filterMessagesByOffset = async function (page: Page, partition: str
 
 export const applyFilter = async function (page: Page) {
   await page.locator('button[aria-label="Search"]').click();
-};
-
-export const expectMessageTableIsNotEmpty = async function (page: Page) {
-  const messageTable = await page.locator('table[aria-label="Messages table"] >> tbody >> tr');
-  await expect(await messageTable.count()).toBeGreaterThan(0);
-};
-
-export const expectMessageTableIsEmpty = async function (page: Page) {
-  const messageTable = await page.locator('table[aria-label="Messages table"] >> tbody >> tr');
-  await expect(await messageTable.count()).toBe(1);
 };

--- a/lib/messages.ts
+++ b/lib/messages.ts
@@ -80,6 +80,5 @@ export const expectMessageTableIsNotEmpty = async function (page: Page) {
 
 export const expectMessageTableIsEmpty = async function (page: Page) {
   const messageTable = await page.locator('table[aria-label="Messages table"] >> tbody >> tr');
-  console.log(await messageTable.count());
   await expect(await messageTable.count()).toBe(1);
 };

--- a/lib/messages.ts
+++ b/lib/messages.ts
@@ -1,0 +1,85 @@
+import { expect, Page } from '@playwright/test';
+
+export enum Limit {
+  ten = 10,
+  twenty = 20,
+  fifty = 50
+}
+
+export enum FilterGroup {
+  offset = 'Offset',
+  timestamp = 'Timestamp',
+  epoch = 'Epoch timestamp',
+  latest = 'Latest messages'
+}
+
+export const setPartition = async function (page: Page, partition: string) {
+  await page.locator('[aria-label="Specify partition value"]').click();
+  await page.locator('[aria-label="Specify partition value"]').fill(partition);
+};
+
+export const pickFilterOption = async function (page: Page, option: FilterGroup) {
+  await page.locator('[data-testid="filter-group"]').click();
+  switch (option) {
+    case FilterGroup.offset: {
+      await page.locator('a:text-is("' + FilterGroup.offset + '")').click();
+      break;
+    }
+    case FilterGroup.timestamp: {
+      await page.locator('a:text-is("' + FilterGroup.timestamp + '")').click();
+      break;
+    }
+    case FilterGroup.epoch: {
+      await page.locator('a:text-is("' + FilterGroup.epoch + '")').click();
+      break;
+    }
+    case FilterGroup.latest: {
+      await page.locator('a:text-is("' + FilterGroup.latest + '")').click();
+      break;
+    }
+  }
+};
+
+export const setOffeset = async function (page: Page, offset: string) {
+  await page.locator('[aria-label="Specify offset"]').click();
+  await page.locator('[aria-label="Specify offset"]').fill(offset);
+};
+
+export const setTimestamp = async function (page: Page, timestamp: string) {
+  await page.locator('[aria-label="Date picker"]').click();
+  await page.locator('[aria-label="Date picker"]').fill(timestamp);
+};
+
+export const setEpoch = async function (page: Page, epochTimestamp: number) {
+  await page.locator('[aria-label="Specify epoch timestamp"]').click();
+  await page.locator('[aria-label="Specify epoch timestamp"]').fill(epochTimestamp.toString());
+};
+
+export const setLimit = async function (page: Page, limit: Limit) {
+  // TODO change 10 to number regex
+  await page.locator('button:has-text("10 messages")').click();
+  await page.locator('li >> button:has-text("' + limit + ' messages")').click();
+};
+
+export const filterMessagesByOffset = async function (page: Page, partition: string, offset: string, limit: Limit) {
+  await setPartition(page, partition);
+  await setOffeset(page, offset);
+  await setLimit(page, limit);
+
+  await applyFilter(page);
+};
+
+export const applyFilter = async function (page: Page) {
+  await page.locator('button[aria-label="Search"]').click();
+};
+
+export const expectMessageTableIsNotEmpty = async function (page: Page) {
+  const messageTable = await page.locator('table[aria-label="Messages table"] >> tbody >> tr');
+  await expect(await messageTable.count()).toBeGreaterThan(0);
+};
+
+export const expectMessageTableIsEmpty = async function (page: Page) {
+  const messageTable = await page.locator('table[aria-label="Messages table"] >> tbody >> tr');
+  console.log(await messageTable.count());
+  await expect(await messageTable.count()).toBe(1);
+};

--- a/tests/kas_messaging.spec.ts
+++ b/tests/kas_messaging.spec.ts
@@ -129,34 +129,6 @@ test('Browse messages', async ({ page }) => {
   await expect(messageDetail.locator('dd:has-text("key-")')).toHaveCount(1);
 });
 
-// test_6acl.py test_kafka_create_consumer_group_and_check_dashboard
-test('create consumer group and check dashboard', async ({ page }) => {
-  const instanceLinkSelector = page.getByText(testInstanceName);
-  const row = page.locator('tr', { has: instanceLinkSelector });
-
-  await navigateToKafkaList(page);
-  await waitForKafkaReady(page, testInstanceName);
-  await row.locator('[aria-label="Actions"]').click();
-  await page.getByText('Connection').click();
-
-  const bootstrapUrl = await getBootstrapUrl(page, testInstanceName);
-  console.log('bootstrapUrl: ' + bootstrapUrl);
-
-  // Consumer
-  await navigateToAccess(page, testInstanceName);
-  await grantConsumerAccess(page, credentials.clientID, testTopicName, consumerGroupId);
-  const consumer = new KafkaConsumer(bootstrapUrl, consumerGroupId, credentials.clientID, credentials.clientSecret);
-  const consumerResponse = await consumer.consumeMessages(testTopicName, expectedMessageCount);
-  expect(consumerResponse).toEqual(expectedMessageCount);
-
-  // Open Consumer Groups Tab to check dashboard
-  await navigateToConsumerGroups(page);
-  await expect(page.getByText(consumerGroupId)).toHaveCount(1);
-
-  await navigateToSAList(page);
-  await deleteServiceAccount(page, testServiceAccountName);
-});
-
 const filters = [FilterGroup.offset, FilterGroup.timestamp, FilterGroup.epoch, FilterGroup.latest];
 for (const filter of filters) {
   test(`Filter messages by ${filter}`, async ({ page }) => {


### PR DESCRIPTION
I added `"playwright/no-conditional-in-test": "off"` to allow conditions in tests for some which are a little bit longer and it makes sense to have conditions inside.

Overall this PR adds tests for filtering messages from https://gitlab.cee.redhat.com/insights-qe/iqe-managed-kafka-plugin/-/blob/master/iqe_managed_kafka/tests/test_6messages.py.