### PR TITLE
Add option to specify admin and comon user to switch between user context

### DIFF
--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -2,7 +2,11 @@ import { expect, Page } from '@playwright/test';
 import blockAnalyticsDomains from './blocker';
 import { config } from './config';
 
-export default async function login(page: Page) {
+export default async function login(
+  page: Page,
+  username: string = config.adminUsername,
+  password: string = config.adminPassword
+) {
   await blockAnalyticsDomains(page);
 
   // Go to starting Page
@@ -12,12 +16,17 @@ export default async function login(page: Page) {
   await expect(page).toHaveTitle(/Log In | Red Hat IDP/);
 
   // do login
-  await page.locator('#username-verification').fill(config.username);
+  await page.locator('#username-verification').fill(username);
   await page.getByText('Next').click();
-  await page.locator('#password').fill(config.password);
+  await page.locator('#password').fill(password);
   await page.locator('#rh-password-verification-submit-button').click();
 
   // check we landed on the right page
   await expect(page).toHaveTitle(/Home/, { timeout: 10000 });
   await expect(page.getByText('Gain increased visibility into your hybrid cloud')).toBeTruthy();
+}
+
+export async function logout(page: Page) {
+  await page.getByRole('button', { name: /User Avatar/ }).click();
+  await page.getByRole('menuitem', { name: 'Log out' }).click();
 }

--- a/lib/config.ts
+++ b/lib/config.ts
@@ -3,6 +3,8 @@ import { v1 as uuid } from 'uuid';
 class Config {
   readonly username: string;
   readonly password: string;
+  readonly adminUsername: string;
+  readonly adminPassword: string;
   readonly startingPage: string;
   readonly sessionID: string;
   readonly instanceName: string;
@@ -19,15 +21,21 @@ class Config {
   readonly startingPageDefault = 'https://console.redhat.com';
 
   constructor() {
+    // Load credentials
     this.username = process.env.TEST_USERNAME;
     this.password = process.env.TEST_PASSWORD;
+    this.adminUsername = process.env.TEST_ADMIN_USERNAME;
+    this.adminPassword = process.env.TEST_ADMIN_PASSWORD;
+    // Setup starting page
     this.startingPage = process.env.STARTING_PAGE || this.startingPageDefault;
+    // Generate names for components
     this.sessionID = uuid().substring(0, 16);
     this.instanceName = process.env.INSTANCE_NAME;
     if (this.instanceName == undefined) {
       this.instanceName = `test-instance-${this.sessionID}`;
     }
 
+    // Timeouts
     this.kafkaInstanceCreationTimeout = 20 * 60 * 1000; // 20 minutes
     this.kafkaInstanceDeletionTimeout = 10 * 60 * 1000; // 10 minutes
 

--- a/tests/basic.spec.ts
+++ b/tests/basic.spec.ts
@@ -1,6 +1,6 @@
 import { test, expect } from '@playwright/test';
 import { config } from '@lib/config';
-import login from '@lib/auth';
+import login, { logout } from '@lib/auth';
 
 // test_1auth.py test_auth_logged_in
 test('perform login', async ({ page }) => {
@@ -24,8 +24,7 @@ test('perform login', async ({ page }) => {
 test('perform login and logout', async ({ page }) => {
   await login(page);
 
-  await page.getByRole('button', { name: /User Avatar/ }).click();
-  await page.getByRole('menuitem', { name: 'Log out' }).click();
+  await logout(page);
 
   await expect(page).toHaveTitle(/Log In | Red Hat IDP/);
 });

--- a/tests/kas_with_instance.spec.ts
+++ b/tests/kas_with_instance.spec.ts
@@ -99,7 +99,7 @@ const filterByOwner = async function (page, name, skipClick = false) {
 
 // test_3kas.py test_kas_kafka_filter_by_owner
 test('test instances can be filtered by owner', async ({ page }) => {
-  await filterByOwner(page, config.username.substring(0, 5));
+  await filterByOwner(page, config.adminUsername.substring(0, 5));
   await expect(page.getByText(testInstanceName)).toBeTruthy();
 
   await filterByOwner(page, 'wrong');
@@ -127,7 +127,7 @@ test('test instances can be filtered by cloud provider', async ({ page }) => {
 
 // test_3kas.py test_kas_kafka_view_details_by_row_click_panel_opened
 test('test instance details on row click', async ({ page }) => {
-  await page.getByRole('gridcell', { name: `${config.username}` }).click();
+  await page.getByRole('gridcell', { name: `${config.adminUsername}` }).click();
 
   await expect(page.locator('h1', { hasText: `${testInstanceName}` })).toHaveCount(1);
 });
@@ -157,7 +157,7 @@ test('test instance quick options', async ({ page }) => {
   await page.getByRole('menuitem', { name: 'Change owner' }).click();
 
   await expect(page.getByText('Current owner')).toHaveCount(1);
-  await expect(page.getByRole('dialog', { name: 'Change owner' }).getByText(config.username)).toHaveCount(1);
+  await expect(page.getByRole('dialog', { name: 'Change owner' }).getByText(config.adminUsername)).toHaveCount(1);
 
   await page.getByRole('button', { name: 'Cancel' }).click();
 });


### PR DESCRIPTION
This change is needed for the option to change between users to verify, that Admin user has different privileges than the common customer user.

See https://issues.redhat.com/browse/MGDSTRM-10155