### PR TITLE
Add Billing tests

### DIFF
--- a/lib/billing.ts
+++ b/lib/billing.ts
@@ -1,5 +1,5 @@
 export enum BillingOptions {
-    PREPAID = "Red Hat prepaid",
-    AWS = "AWS Marketplace",
-    RH = "Red Hat Marketplace"
+  PREPAID = 'Red Hat prepaid',
+  AWS_MARKETPLACE = 'AWS Marketplace',
+  RH_MARKETPLACE = 'Red Hat Marketplace'
 }

--- a/lib/billing.ts
+++ b/lib/billing.ts
@@ -1,0 +1,5 @@
+export enum BillingOptions {
+    PREPAID = "Red Hat prepaid",
+    AWS = "AWS Marketplace",
+    RH = "Red Hat Marketplace"
+}

--- a/lib/config.ts
+++ b/lib/config.ts
@@ -5,6 +5,13 @@ class Config {
   readonly password: string;
   readonly adminUsername: string;
   readonly adminPassword: string;
+  // Billing credentials
+  readonly stratosphere1username: string;
+  readonly stratosphere2username: string;
+  readonly stratosphere3username: string;
+  readonly stratosphere4username: string;
+  readonly stratospherePassword: string;
+
   readonly startingPage: string;
   readonly sessionID: string;
   readonly instanceName: string;
@@ -26,6 +33,12 @@ class Config {
     this.password = process.env.TEST_PASSWORD;
     this.adminUsername = process.env.TEST_ADMIN_USERNAME;
     this.adminPassword = process.env.TEST_ADMIN_PASSWORD;
+    this.stratosphere1username = process.env.STRATOSPHERE_SCENARIO_1_USER;
+    this.stratosphere2username = process.env.STRATOSPHERE_SCENARIO_2_USER;
+    this.stratosphere3username = process.env.STRATOSPHERE_SCENARIO_3_USER;
+    this.stratosphere4username = process.env.STRATOSPHERE_SCENARIO_4_USER;
+    this.stratospherePassword = process.env.STRATOSPHERE_SCENARIO_PASSWORD;
+
     // Setup starting page
     this.startingPage = process.env.STARTING_PAGE || this.startingPageDefault;
     // Generate names for components

--- a/lib/kafka.ts
+++ b/lib/kafka.ts
@@ -1,6 +1,7 @@
 import { expect, Page } from '@playwright/test';
 import { config } from './config';
 import { closePopUp } from './popup';
+import { BillingOptions } from './billing';
 
 export const navigateToApplicationAndDataServices = async function (page: Page) {
   if (!(await page.locator('button', { hasText: 'Streams for Apache Kafka' }).isVisible())) {
@@ -24,7 +25,12 @@ export const navigateToKafkaList = async function (page: Page) {
   await expect(await page.locator('h1', { hasText: 'Kafka Instances' })).toHaveCount(1);
 };
 
-export const createKafkaInstance = async function (page: Page, name: string, check = true) {
+export const createKafkaInstance = async function (
+  page: Page,
+  name: string,
+  check = true,
+  billingOption = BillingOptions.PREPAID
+) {
   await page.locator('button', { hasText: 'Create Kafka instance' }).click();
   await expect(page.getByText('Create a Kafka instance')).toHaveCount(1);
   await page.waitForSelector('[role=progressbar]', { state: 'detached' });
@@ -35,6 +41,14 @@ export const createKafkaInstance = async function (page: Page, name: string, che
   await page.getByLabel('Name *').click();
 
   await page.getByLabel('Name *').fill(name);
+
+  // Set billing options
+  try {
+    await page.locator('div:text-is("' + billingOption + '")').click();
+  } catch (err) {
+    // Billing option is not available so do nothing
+  }
+
   // data-testid=modalCreateKafka-buttonSubmit
   await page.locator('button', { hasText: 'Create instance' }).click();
 
@@ -180,4 +194,4 @@ export const navigateToConsumerGroups = async function (page: Page) {
 export const showKafkaDetails = async function (page: Page) {
   await page.locator('main >> [aria-label="Actions"]').click();
   await page.locator('button', { hasText: 'Details' }).click();
-}
+};

--- a/lib/kafka.ts
+++ b/lib/kafka.ts
@@ -176,3 +176,8 @@ export const navigateToAccess = async function (page: Page, kafkaName: string) {
 export const navigateToConsumerGroups = async function (page: Page) {
   await page.getByTestId('pageKafka-tabConsumers').click();
 };
+
+export const showKafkaDetails = async function (page: Page) {
+  await page.locator('main >> [aria-label="Actions"]').click();
+  await page.locator('button', { hasText: 'Details' }).click();
+}

--- a/tests/billing.spec.ts
+++ b/tests/billing.spec.ts
@@ -1,0 +1,50 @@
+import login from "@lib/auth";
+import { BillingOptions } from "@lib/billing";
+import { config } from "@lib/config";
+import { createKafkaInstance, deleteKafkaInstance, navigateToKafkaList, showKafkaDetails } from "@lib/kafka";
+import test, { Page } from "@playwright/test";
+
+const testInstanceName = 'mk-ui-playwright-tests';
+let currentUsername = config.stratosphere1username
+
+test.afterEach(async ({ page }) => {
+    await login(page, currentUsername, config.stratospherePassword);
+    await navigateToKafkaList(page);
+    await deleteKafkaInstance(page, testInstanceName);
+})
+
+async function setupKafkaFreshInstance(page: Page) {
+    await navigateToKafkaList(page);
+    await deleteKafkaInstance(page, testInstanceName);
+    await createKafkaInstance(page, testInstanceName, false);
+}
+  
+// Tests that user with all different billing options can create Kafka succesfully
+const users = [config.stratosphere1username, config.stratosphere2username, config.stratosphere3username]
+for (const user of users) {
+    test(`Billing check of user: ${user}`, async ({ page }) => {
+        currentUsername = user
+        await login(page, user, config.stratospherePassword);
+    
+        await setupKafkaFreshInstance(page);
+        await showKafkaDetails(page);
+    })
+}
+
+// Tests that different billing options are properly set in instance details
+const billingOptions = [BillingOptions.AWS, BillingOptions.RH, BillingOptions.PREPAID]
+for (const billingOption of billingOptions) {
+    test(`Billing option for stratosphere4: ${billingOption}`, async ({ page }) => {
+        currentUsername = config.stratosphere4username
+        await login(page, currentUsername, config.stratospherePassword);
+        
+        switch(billingOption) {
+            case BillingOptions.PREPAID:
+                break;
+            case BillingOptions.AWS:
+                break;
+            case BillingOptions.RH:
+                break;
+        }
+    })
+}

--- a/tests/billing.spec.ts
+++ b/tests/billing.spec.ts
@@ -60,18 +60,7 @@ test.describe('Stratosphere users has to be defined for these tests', () => {
     test(`Billing option for ${config.stratosphere3username}: ${billingOption}`, async ({ page }) => {
       currentUsername = config.stratosphere3username;
       await login(page, currentUsername, config.stratospherePassword);
-
-      switch (billingOption) {
-        case BillingOptions.PREPAID:
-          await performBillingTest(page, billingOption);
-          break;
-        case BillingOptions.AWS_MARKETPLACE:
-          await performBillingTest(page, billingOption);
-          break;
-        case BillingOptions.RH_MARKETPLACE:
-          await performBillingTest(page, billingOption);
-          break;
-      }
+      await performBillingTest(page, billingOption);
     });
   }
 });

--- a/tests/billing.spec.ts
+++ b/tests/billing.spec.ts
@@ -1,50 +1,78 @@
-import login from "@lib/auth";
-import { BillingOptions } from "@lib/billing";
-import { config } from "@lib/config";
-import { createKafkaInstance, deleteKafkaInstance, navigateToKafkaList, showKafkaDetails } from "@lib/kafka";
-import test, { Page } from "@playwright/test";
+import login from '@lib/auth';
+import { BillingOptions } from '@lib/billing';
+import { config } from '@lib/config';
+import { createKafkaInstance, deleteKafkaInstance, navigateToKafkaList, showKafkaDetails } from '@lib/kafka';
+import test, { Page, expect } from '@playwright/test';
 
 const testInstanceName = 'mk-ui-playwright-tests';
-let currentUsername = config.stratosphere1username
+let currentUsername = config.stratosphere1username;
 
-test.afterEach(async ({ page }) => {
-    await login(page, currentUsername, config.stratospherePassword);
+test.describe('Stratosphere users has to be defined for these tests', () => {
+  if (
+    config.stratosphere1username == undefined ||
+    config.stratosphere2username == undefined ||
+    config.stratosphere3username == undefined ||
+    config.stratosphere4username == undefined
+  ) {
+    console.log('test se skipne');
+    test.skip();
+  }
+
+  test.afterEach(async ({ page }) => {
+    try {
+      await login(page, currentUsername, config.stratospherePassword);
+    } catch (err) {
+      // Already logged in, do nothing
+    }
     await navigateToKafkaList(page);
     await deleteKafkaInstance(page, testInstanceName);
-})
+  });
 
-async function setupKafkaFreshInstance(page: Page) {
+  async function setupKafkaFreshInstance(page: Page, billingOption: BillingOptions) {
     await navigateToKafkaList(page);
-    await deleteKafkaInstance(page, testInstanceName);
-    await createKafkaInstance(page, testInstanceName, false);
-}
-  
-// Tests that user with all different billing options can create Kafka succesfully
-const users = [config.stratosphere1username, config.stratosphere2username, config.stratosphere3username]
-for (const user of users) {
+    await expect(page.getByRole('button', { name: 'Create Kafka instance' })).toBeVisible();
+    if ((await page.getByText(testInstanceName).count()) == 1) {
+      await deleteKafkaInstance(page, testInstanceName);
+    }
+    await createKafkaInstance(page, testInstanceName, false, billingOption);
+  }
+
+  async function performBillingTest(page: Page, billingOption: BillingOptions) {
+    await setupKafkaFreshInstance(page, billingOption);
+    await showKafkaDetails(page);
+    await expect(await page.locator('dd:has-text("' + billingOption + '")')).toHaveCount(1);
+  }
+
+  // Tests that user with all different billing options can create Kafka succesfully
+  const users = [config.stratosphere1username, config.stratosphere2username, config.stratosphere4username];
+  for (const user of users) {
     test(`Billing check of user: ${user}`, async ({ page }) => {
-        currentUsername = user
-        await login(page, user, config.stratospherePassword);
-    
-        await setupKafkaFreshInstance(page);
-        await showKafkaDetails(page);
-    })
-}
+      currentUsername = user;
+      await login(page, user, config.stratospherePassword);
 
-// Tests that different billing options are properly set in instance details
-const billingOptions = [BillingOptions.AWS, BillingOptions.RH, BillingOptions.PREPAID]
-for (const billingOption of billingOptions) {
-    test(`Billing option for stratosphere4: ${billingOption}`, async ({ page }) => {
-        currentUsername = config.stratosphere4username
-        await login(page, currentUsername, config.stratospherePassword);
-        
-        switch(billingOption) {
-            case BillingOptions.PREPAID:
-                break;
-            case BillingOptions.AWS:
-                break;
-            case BillingOptions.RH:
-                break;
-        }
-    })
-}
+      await setupKafkaFreshInstance(page, BillingOptions.PREPAID);
+      await showKafkaDetails(page);
+    });
+  }
+
+  // Tests that different billing options are properly set in instance details
+  const billingOptions = [BillingOptions.AWS_MARKETPLACE, BillingOptions.RH_MARKETPLACE, BillingOptions.PREPAID];
+  for (const billingOption of billingOptions) {
+    test(`Billing option for ${config.stratosphere3username}: ${billingOption}`, async ({ page }) => {
+      currentUsername = config.stratosphere3username;
+      await login(page, currentUsername, config.stratospherePassword);
+
+      switch (billingOption) {
+        case BillingOptions.PREPAID:
+          await performBillingTest(page, billingOption);
+          break;
+        case BillingOptions.AWS_MARKETPLACE:
+          await performBillingTest(page, billingOption);
+          break;
+        case BillingOptions.RH_MARKETPLACE:
+          await performBillingTest(page, billingOption);
+          break;
+      }
+    });
+  }
+});

--- a/tests/billing.spec.ts
+++ b/tests/billing.spec.ts
@@ -14,7 +14,6 @@ test.describe('Stratosphere users has to be defined for these tests', () => {
     config.stratosphere3username == undefined ||
     config.stratosphere4username == undefined
   ) {
-    console.log('test se skipne');
     test.skip();
   }
 


### PR DESCRIPTION
This PR adds tests for different billing types. As a prerequisite the user has to specify the following env vars:

```
STRATOSPHERE_SCENARIO_1_USER
STRATOSPHERE_SCENARIO_2_USER
STRATOSPHERE_SCENARIO_3_USER
STRATOSPHERE_SCENARIO_4_USER
STRATOSPHERE_SCENARIO_PASSWORD
```

When the env vars are not specified the tests will be skipped. 

Shouldn't be merged before https://github.com/redhat-developer/consoledot-e2e/pull/61 as it depends on it!