### PR TITLE
Click properly on Actions for elements

### DIFF
--- a/lib/kafka.ts
+++ b/lib/kafka.ts
@@ -60,10 +60,8 @@ export const createKafkaInstance = async function (
 };
 
 export const deleteKafkaInstance = async function (page: Page, name: string, awaitDeletion = true) {
-  const instanceLinkSelector = page.getByText(name);
-  const row = page.locator('tr', { has: instanceLinkSelector });
   try {
-    await row.locator('[aria-label="Actions"]').click();
+    await showElementActions(page, name);
     await page.locator('button', { hasText: 'Delete instance' }).click();
     try {
       await expect(page.locator('input[name="mas-name-input"]')).toHaveCount(1, { timeout: 5000 });
@@ -104,9 +102,7 @@ export const waitForKafkaReady = async function (page: Page, name: string) {
 
 export const getBootstrapUrl = async function (page: Page, name: string) {
   await navigateToKafkaList(page);
-  const instanceLinkSelector = page.getByText(name);
-  const row = page.locator('tr', { has: instanceLinkSelector });
-  await row.locator('[aria-label="Actions"]').click();
+  await showElementActions(page, name);
 
   await page.locator('button', { hasText: 'Connection' }).click();
 
@@ -191,7 +187,14 @@ export const navigateToConsumerGroups = async function (page: Page) {
   await page.getByTestId('pageKafka-tabConsumers').click();
 };
 
-export const showKafkaDetails = async function (page: Page) {
-  await page.locator('main >> [aria-label="Actions"]').click();
+export const showElementActions = async function (page: Page, instanceName: string) {
+  const instanceLinkSelector = page.getByText(instanceName);
+  const row = page.locator('tr', { has: instanceLinkSelector });
+
+  await row.locator('[aria-label="Actions"]').click();
+};
+
+export const showKafkaDetails = async function (page: Page, instanceName: string) {
+  await showElementActions(page, instanceName);
   await page.locator('button', { hasText: 'Details' }).click();
 };

--- a/lib/kafka.ts
+++ b/lib/kafka.ts
@@ -44,7 +44,7 @@ export const createKafkaInstance = async function (
 
   // Set billing options
   try {
-    await page.locator('div:text-is("' + billingOption + '")').click();
+    await page.locator('div:text-is("' + billingOption + '")').click({ timeout: 1000 });
   } catch (err) {
     // Billing option is not available so do nothing
   }

--- a/lib/sa.ts
+++ b/lib/sa.ts
@@ -1,6 +1,7 @@
 import { expect, Page } from '@playwright/test';
 import { config } from './config';
 import { closePopUp } from './popup';
+import { showElementActions } from './kafka';
 
 export const navigateToSAList = async function (page: Page) {
   try {
@@ -48,11 +49,11 @@ export const createServiceAccount = async function (page: Page, name: string) {
 };
 
 export const deleteServiceAccount = async function (page: Page, name: string) {
-  const instanceLinkSelector = page.getByText(name, { exact: true });
+  const saLinkSelector = page.getByText(name, { exact: true });
 
-  let count = await instanceLinkSelector.count();
+  let count = await saLinkSelector.count();
   while (count > 0) {
-    const row = page.locator('tr', { has: instanceLinkSelector.nth(0) });
+    const row = page.locator('tr', { has: saLinkSelector.nth(0) });
 
     await row.locator('[aria-label="Actions"]').nth(0).click();
 
@@ -62,7 +63,7 @@ export const deleteServiceAccount = async function (page: Page, name: string) {
     // #confirm__button
     await page.locator('button', { hasText: 'Delete' }).click();
 
-    await expect(instanceLinkSelector).toHaveCount(count - 1);
+    await expect(saLinkSelector).toHaveCount(count - 1);
 
     count--;
   }
@@ -74,10 +75,7 @@ export const deleteServiceAccount = async function (page: Page, name: string) {
 };
 
 export const resetServiceAccount = async function (page: Page, name: string) {
-  const instanceLinkSelector = page.getByText(name);
-  const row = page.locator('tr', { has: instanceLinkSelector });
-
-  await row.locator('[aria-label="Actions"]').click();
+  await showElementActions(page, name);
 
   await page.locator('button', { hasText: 'Reset credentials' }).click();
 

--- a/lib/topic.ts
+++ b/lib/topic.ts
@@ -1,5 +1,5 @@
 import { expect, Page } from '@playwright/test';
-import { navigateToKafkaList, waitForKafkaReady } from './kafka';
+import { navigateToKafkaList, showElementActions, waitForKafkaReady } from './kafka';
 
 export const navigateToKafkaTopicsList = async function (page: Page, kafkaName: string) {
   await expect(page.getByText(kafkaName)).toHaveCount(1);
@@ -23,10 +23,7 @@ export const createKafkaTopic = async function (page: Page, name: string) {
 };
 
 export const deleteKafkaTopic = async function (page: Page, name: string) {
-  const instanceLinkSelector = page.getByText(name);
-  const row = page.locator('tr', { has: instanceLinkSelector });
-
-  await row.locator('[aria-label="Actions"]').click();
+  await showElementActions(page, name);
   // data-testid=tableTopics-actionDelete
   await page.locator('button', { hasText: 'Delete' }).click();
   await page.getByLabel('Type DELETE to confirm:').click();

--- a/tests/billing.spec.ts
+++ b/tests/billing.spec.ts
@@ -38,7 +38,7 @@ test.describe('Billing test cases', () => {
 
   async function performBillingTest(page: Page, billingOption: BillingOptions) {
     await setupKafkaFreshInstance(page, billingOption);
-    await showKafkaDetails(page);
+    await showKafkaDetails(page, testInstanceName);
     await expect(await page.locator('dd:has-text("' + billingOption + '")')).toHaveCount(1);
   }
 
@@ -47,12 +47,12 @@ test.describe('Billing test cases', () => {
   // This is needed to avoid same names of the tests which results into playwright execution failure
   let index = 0;
   for (const user of users) {
-    test(`Billing check of user - ${index}${user}`, async ({ page }) => {
+    test(`Billing check of user - ${index}#${user}`, async ({ page }) => {
       currentUsername = user;
       await login(page, user, config.stratospherePassword);
 
       await setupKafkaFreshInstance(page, BillingOptions.PREPAID);
-      await showKafkaDetails(page);
+      await showKafkaDetails(page, testInstanceName);
     });
     index++;
   }

--- a/tests/billing.spec.ts
+++ b/tests/billing.spec.ts
@@ -18,11 +18,6 @@ test.describe('Billing test cases', () => {
   );
 
   test.afterEach(async ({ page }) => {
-    try {
-      await login(page, currentUsername, config.stratospherePassword);
-    } catch (err) {
-      // Already logged in, do nothing
-    }
     await navigateToKafkaList(page);
     await deleteKafkaInstance(page, testInstanceName);
   });

--- a/tests/kas_with_instance.spec.ts
+++ b/tests/kas_with_instance.spec.ts
@@ -1,7 +1,13 @@
 import { test, expect } from '@playwright/test';
 import login from '@lib/auth';
 import { config } from '@lib/config';
-import { navigateToKafkaList, deleteKafkaInstance, createKafkaInstance, waitForKafkaReady } from '@lib/kafka';
+import {
+  navigateToKafkaList,
+  deleteKafkaInstance,
+  createKafkaInstance,
+  waitForKafkaReady,
+  showElementActions
+} from '@lib/kafka';
 import { navigateToKafkaTopicsList, createKafkaTopic, deleteKafkaTopic } from '@lib/topic';
 
 const testInstanceName = config.instanceName;
@@ -134,7 +140,7 @@ test('test instance details on row click', async ({ page }) => {
 
 // test_3kas.py test_kas_kafka_view_details_by_menu_click_panel_opened
 test('test instance details on menu click', async ({ page }) => {
-  await page.locator('main >> [aria-label="Actions"]').click();
+  await showElementActions(page, testInstanceName);
   await page.locator('button', { hasText: 'Details' }).click();
 
   await expect(page.locator('h1', { hasText: `${testInstanceName}` })).toHaveCount(1);
@@ -146,14 +152,14 @@ test('test instance details on menu click', async ({ page }) => {
 // test_3kas.py test_kas_kafka_view_details_by_connection_menu_click_panel_opened
 // ... and more ...
 test('test instance quick options', async ({ page }) => {
-  await page.locator('main >> [aria-label="Actions"]').click();
+  await showElementActions(page, testInstanceName);
   await page.locator('button', { hasText: 'Connection' }).click();
 
   await expect(page.getByRole('textbox', { name: 'Bootstrap server' })).toHaveCount(1);
 
   await page.locator('button[aria-label="Close drawer panel"]').click();
 
-  await page.locator('main >> [aria-label="Actions"]').click();
+  await showElementActions(page, testInstanceName);
   await page.getByRole('menuitem', { name: 'Change owner' }).click();
 
   await expect(page.getByText('Current owner')).toHaveCount(1);


### PR DESCRIPTION
This PR changes the way how we click on `Actions`. We should always find the proper row in the table because pw sometimes resolves it into two elements and that is not expected of course. 

It also changes the consumer logic to allow us to use it in `retry` function. For some reason, the catch part didn't work at all.