### PR TITLE
Pin GH Actions using the commit SHA

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -69,7 +69,8 @@ jobs:
 
     - name: Check results file existence
       id: check_results
-      uses: andstor/file-existence-action@v1
+      # v1
+      uses: andstor/file-existence-action@f02338908d150e00a4b8bebc2dad18bd9e5229b0
       with:
         files: "results.xml"
     - name: Release


### PR DESCRIPTION
We should apply the Security Hardening best practices when dealing with GH Actions workflows that have access to sensitive data (e.g. the Secrets).

https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-third-party-actions