### PR TITLE
Allow to enable err logging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ node_modules/
 .*_env
 .DS_Store
 .idea
+results.xml

--- a/Readme.md
+++ b/Readme.md
@@ -60,7 +60,12 @@ PWDEBUG=1 npx playwright test --project chromium --debug
 
 For enabling slow mode 1s for debugging use
 ```bash
-SLOW_MODE=1000 playwright test
+SLOW_MODE=1000 npx playwright test
+```
+
+For enabling error logging use
+```bash
+ENABLE_ERR_LOGGING=1 npx playwright test
 ```
 
 ### Setup

--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -1,6 +1,7 @@
 import { expect, Page } from '@playwright/test';
 import blockAnalyticsDomains from './blocker';
 import { config } from './config';
+import { addConsoleLogListeners } from './console_err_listener';
 
 export default async function login(
   page: Page,
@@ -8,6 +9,11 @@ export default async function login(
   password: string = config.adminPassword
 ) {
   await blockAnalyticsDomains(page);
+
+  // move that into page object model when it will be implemented
+  if (config.enableErrLogging) {
+    addConsoleLogListeners(page);
+  }
 
   // Go to starting Page
   await page.goto(config.startingPage);

--- a/lib/config.ts
+++ b/lib/config.ts
@@ -31,6 +31,8 @@ class Config {
 
   readonly startingPageDefault = 'https://console.redhat.com';
 
+  readonly enableErrLogging: boolean;
+
   constructor() {
     // Load credentials
     this.username = process.env.TEST_USERNAME;
@@ -64,6 +66,9 @@ class Config {
 
     this.serviceAccountCreationTimeout = 30 * 1000; // 30 seconds
     this.serviceAccountDeletionTimeout = 30 * 1000; // 30 seconds
+
+    //logging
+    this.enableErrLogging = !!process.env.ENABLE_ERR_LOGGING;
   }
 }
 

--- a/lib/console_err_listener.ts
+++ b/lib/console_err_listener.ts
@@ -1,0 +1,18 @@
+import { Page } from '@playwright/test';
+
+/**
+  Adds consolelog listeners
+ */
+export const addConsoleLogListeners = async function (page: Page) {
+  page.on('console', (msg) => {
+    if (msg.type() === 'error') console.error(`Error: "${msg.text()}"`);
+  });
+
+  page.on('pageerror', (err) => {
+    console.error(`PageError: ${err.message}`);
+  });
+
+  page.on('requestfailed', (request) => {
+    console.error(`Request failed: ${request.url()} ${request.failure().errorText}`);
+  });
+};

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -32,7 +32,7 @@ const config: PlaywrightTestConfig = {
   /* Opt out of parallel tests. */
   workers: 1,
   /* Reporter to use. See https://playwright.dev/docs/test-reporters */
-  reporter: process.env.CI ? [['line'], ['github'], ['junit', { outputFile: 'results.xml' }]] : 'html',
+  reporter: process.env.CI ? [['list', { printSteps: true }], ['github'], ['junit', { outputFile: 'results.xml' }]] : 'html',
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
   use: {
     /* Maximum time each action such as `click()` can take. Defaults to 10000 (0 means no limit). */


### PR DESCRIPTION
Be able to log page errors like failed requests, pageerror or console.errors on stderr. This can be enabled in CI systems and then report portal will have more inputs to run autoanalysis.