### PR TITLE
Disable edit topic properties after creation as there is a race in wating for topic table that should be fixed at first

### DIFF
--- a/tests/rhosak/kas_with_instance.spec.ts
+++ b/tests/rhosak/kas_with_instance.spec.ts
@@ -269,6 +269,7 @@ test('create Topic with properties different than default', async ({ page }) => 
 
 // test_4kafka.py test_edit_topic_properties_after_creation
 test('edit topic properties after creation', async ({ page }) => {
+  test.fixme(true, 'Test is extremely flaky. Topics are not cleared and we need to wait properly on loading instead of just cliking without it.');
   await navigateToKafkaTopicsList(page, testInstanceName);
   await createKafkaTopic(page, testTopicName, true);
 

--- a/tests/rhosak/kas_with_instance.spec.ts
+++ b/tests/rhosak/kas_with_instance.spec.ts
@@ -269,7 +269,10 @@ test('create Topic with properties different than default', async ({ page }) => 
 
 // test_4kafka.py test_edit_topic_properties_after_creation
 test('edit topic properties after creation', async ({ page }) => {
-  test.fixme(true, 'Test is extremely flaky. Topics are not cleared and we need to wait properly on loading instead of just cliking without it.');
+  test.fixme(
+    true,
+    'Test is extremely flaky. Topics are not cleared and we need to wait properly on loading instead of just cliking without it.'
+  );
   await navigateToKafkaTopicsList(page, testInstanceName);
   await createKafkaTopic(page, testTopicName, true);
 


### PR DESCRIPTION
Disable `edit topic properties after creation` as it contains the wrong wait for topic deletion in afterEach phase. This is a temporary solution until we will fix it properly.