### PR TITLE
Add blocking of pendo and analytics scripts

### DIFF
--- a/lib/utils/blocker.ts
+++ b/lib/utils/blocker.ts
@@ -2,7 +2,7 @@ import { Page } from '@playwright/test';
 
 export default async function blockAnalyticsDomains(page: Page) {
   await page.route('**/*', (route) => {
-    const blockedUrls = ['trustarc', 'dpal.js', 'analytics', 'segment.com'];
+    const blockedUrls = ['trustarc', 'dpal.js', 'analytics', 'segment.com', 'pendo', 'AppMeasurement'];
     const url = route.request().url();
     return blockedUrls.some((blocked) => url.includes(blocked)) ? route.abort() : route.continue();
   });


### PR DESCRIPTION
In some cases after a while pendo scripts or analytics scripts spawn modals or feedback forms. 